### PR TITLE
Fixed footer, contribute page, and community page on mobile

### DIFF
--- a/_sass/_base.scss
+++ b/_sass/_base.scss
@@ -164,7 +164,7 @@ a:hover {
 }
 
 /**
- * Contibute Page
+ * Contribute Page
  */
 
 #contribute-col-wrapper {
@@ -239,7 +239,7 @@ a:hover {
 }
 
 /**
- * Overriding the nav bar when used with a mobile device
+ * Overriding the nav bar and footer when used with a mobile device
  */
 
 @media only screen and (max-width: 600px) {
@@ -302,4 +302,43 @@ a:hover {
   }
 }
 
+#contribute-col-wrapper {
+  width: 100%;
+  float: none;
+}
+
+#contribute_col {
+  width: 90%;
+  float: none;
+}
+
+#community-col-wrapper, #community-dev-col-wrapper {
+ width: 100%;
+ float: none;
+}
+
+#community_col, #community-dev_col {
+ width: 90%;
+ float: none;
+ padding: 10px;
+ margin: 5px;
+}
+
+#dev-community-intro {
+    clear: none;
+}
+
+#colophon {
+  float: none;
+  clear: none;
+  #footer_col {
+    float: none;
+    width: 100%;
+    text-align: center;
+    h3 {
+      margin-bottom: 0.5em;
+      font-size: 1.5em;
+    }
+  }
+}
 }


### PR DESCRIPTION
I have made several changes to base.scss to change how the site displays on mobile. The footer columns now line up underneath each other, as do columns on the contribute and community pages. I would like someone else to take a look at this branch before I merge, if possible.

Here is a screenshot of the Contribute page:

![contributepage](https://cloud.githubusercontent.com/assets/5250014/13249549/da6f0ec4-da1c-11e5-9c54-de286229499b.png)

And here is one of the Community page:

![communitypage](https://cloud.githubusercontent.com/assets/5250014/13249557/e8b64588-da1c-11e5-8330-bee6555def81.png)
