### PR TITLE
Update the Download Page for 1.9

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -7,6 +7,7 @@ markdown: kramdown
 
 # TripleA version information. Update each time a new version is released.
 triplea-version: 1.8.0.9
-windows-link: https://github.com/triplea-game/triplea/releases/download/1.8.0.9/triplea_1_8_0_9_windows_installer.exe
-mac-link: https://github.com/triplea-game/triplea/releases/download/1.8.0.9/triplea_1_8_0_9_mac.dmg
-linux-link: https://github.com/triplea-game/triplea/releases/download/1.8.0.9/triplea_1_8_0_9_all_platforms.zip
+windows-32bit-link: https://github.com/triplea-game/triplea/releases/download/1.9.0.0.2984/TripleA_1.9.0.0.2984_windows-32bit.exe 
+windows-64bit-link: https://github.com/triplea-game/triplea/releases/download/1.9.0.0.2984/TripleA_1.9.0.0.2984_windows-64bit.exe
+mac-link: https://github.com/triplea-game/triplea/releases/download/1.9.0.0.2984/TripleA_1.9.0.0.2984_macos.dmg
+linux-link: https://github.com/triplea-game/triplea/releases/download/1.9.0.0.2984/TripleA_1.9.0.0.2984_unix.sh 

--- a/_sass/_base.scss
+++ b/_sass/_base.scss
@@ -172,7 +172,7 @@ a:hover {
 }
 
 .dl-links {
-  width: 27.514%;
+  width: 18%;
 }
 
 .dl-links p {
@@ -180,7 +180,7 @@ a:hover {
 }
 
 .dl-install4j-credit, .dl-direct-link, .rulebook-reminder {
-  text-align: center;
+  text-align: right;
 }
 
 .installation-instructions {

--- a/download.html
+++ b/download.html
@@ -3,63 +3,69 @@ layout: page
 title: Download
 permalink: /download/
 ---
-
-<a href="{{ site.windows-link }}" target="_blank" class="button dl-links" onclick="hideShowInstallationText(document.getElementById('windows-install'))">
+  <p class="dl-install4j-credit"><small>Installer powered by <a href="http://www.ej-technologies.com/products/install4j/overview.html"><img src="../images/install4j_small.png" title="multi-platform installer builder" /></a></small></p>
+<p>Select below to begin downloading the TripleA installer:</p>
+<a href="{{ site.windows-64bit-link }}" target="_blank" class="button dl-links" onclick="hideShowInstallationText(document.getElementById('windows-install'))">
   <img src="../images/operating-systems/windows100.png" />
-  <p>Download TripleA {{ site.triplea-version }} for Windows</p>
+  <p>TripleA for Windows <strong>(64 bit)</strong></p>
+</a>
+<a href="{{ site.windows-32bit-link }}" target="_blank" class="button dl-links" onclick="hideShowInstallationText(document.getElementById('windows-install'))">
+  <img src="../images/operating-systems/windows100.png" />
+  <p>TripleA for Windows <strong>(32 bit)</strong></p>
 </a>
 <a href="{{ site.mac-link }}" target="_blank" class="button dl-links" onclick="hideShowInstallationText(document.getElementById('mac-install'))">
   <img src="../images/operating-systems/mac100.png" />
-  <p>Download TripleA {{ site.triplea-version }} for Mac</p>
+  <p>TripleA for Mac</p>
 </a>
 <a href="{{ site.linux-link }}" target="_blank" class="button dl-links" onclick="hideShowInstallationText(document.getElementById('linux-install'))">
   <img src="../images/operating-systems/linux100.png" />
-  <p>Download TripleA {{ site.triplea-version }} for Linux</p>
+  <p>TripleA for Linux</p>
 </a>
 
-<p class="dl-direct-link">Having trouble with the installation link? Get a direct link <a href="https://github.com/triplea-game/triplea/releases/tag/{{ site.triplea-version }}">here</a>.</p>
-<p class="dl-direct-link">New to TripleA? Check out the <a href="../files/TripleA_RuleBook.pdf">Rulebook</a></p>
-<p class="dl-direct-link">View the <a href="/release_notes">release notes</a></p>
 
-<p class="dl-direct-link">
-Download Prerelease 1.9.0.0.2972:
-<a href="https://github.com/triplea-game/triplea/releases/download/1.9.0.0.2972/TripleA_windows-x64_1.9.0.0.2972.exe">Windows 64bit</a>
-- <a href="https://github.com/TripleA-game/triplea/releases/download/1.9.0.0.2972/TripleA_windows_1.9.0.0.2972.exe">Windows 32bit</a>
-- <a href="https://github.com/triplea-game/triplea/releases/download/1.9.0.0.2972/TripleA_macos_1.9.0.0.2972.dmg">Mac</a>
-- <a href="https://github.com/TripleA-game/triplea/releases/download/1.9.0.0.2972/TripleA_unix_1.9.0.0.2972.sh">Linux</a>
 </p>
-<br />
-<p class="dl-install4j-credit">Installer powered by <a href="http://www.ej-technologies.com/products/install4j/overview.html"><img src="../images/install4j_small.png" title="multi-platform installer builder" /></a></p>
+<br/>
 
 
 <div id="windows-install" class="installation-instructions">
   <h2>Windows Installation</h2>
-  <p>You may need to <a href="http://java.com/">download</a> and install Java, if you do not already have it.</p>
-  <p> (The latest version is {{ site.triplea-version }}.).</code>.</p>
-  <p>Run the installer, and you can now run TripleA from the start menu.</p>
-  <p>If you already have Java 8 installed, then you can download the file called <code>triplea_{{ site.triplea-version }}_windows_installer.exe</code></p>
-  <p>Run the installer, and you will be able to launch TripleA from your start menu.</p>
+  <p>Run the installer once the download completes</p>
+  <p>Follow the on-screen prompts to finish the installation</p> 
+  <p>When the installation is complete, you will be able to launch TripleA from the start menu.</p>
+  <br />
+  <p">New to TripleA? Check out the <a href="../files/TripleA_RuleBook.pdf">Rulebook</a></p>
+  <p>Upgrading? See what has changed in the <a href="/release_notes">release notes</a></p>
   <p><a href="#" onclick="hideShowInstallationText(document.getElementById('windows-install'))">(Hide)</a></p>
 </div>
 
 <div id="mac-install" class="installation-instructions">
   <h2>Mac OS X Installation</h2>
-  <p>Download the latest mac version of TripleA, which will be called <code>triplea_{{ site.triplea-version }}_mac.dmg</code>.</p>
-  <p>Double click on the DMG file, and drag TripleA.app to your applications folder. Double click on TripleA.app to run. If you do not have Java already installed, Mac OS X will promt you to download it.</p>
-
-  <p>If you get a "TripleA is damaged and cannot be opened" waning, follow these steps:</p>
+  <p> The installer is a standard Mac DMG installation file.</p>
+  <p>Once the DMG installer has finished downloading, double click it to start the installation</p>
+  <p>Within the insallation window, simply drag the TripleA.app icon to the Applications folder</p>
+  <p>Double click TripleA.app to run the game.</p>
+  <p>If you do not have Java already installed, Mac OS X will promt you to download it.</p>
+  <p>For detailed help of how to install from a DMG, please see this <a href="http://www.howtogeek.com/177619/how-to-install-applications-on-a-mac-everything-you-need-to-know/">how-to article</a>.</p>
+  <br/>
+  <p>If you get a "TripleA is damaged and cannot be opened" warning, follow these steps:</p>
   <p>Apple menu > System Preferences > Security & Privacy > General tab under the header "Allow applications downloaded from:"</p>
   <p>Change "Allow Applications Downloaded From:" to "Anywhere"</p>
-
-  <p>Your setting will reset to "Mac App Store and identified developers" to secure your computer from malware in 30 days, so you must repeat this each time you update TripleA.
+  <p>This setting will reset to "Mac App Store and identified developers" every 30 days, you may need to repeat this step.</p>
+  <br />
+  <p">New to TripleA? Check out the <a href="../files/TripleA_RuleBook.pdf">Rulebook</a></p>
+  <p>Upgrading? See what has changed in the <a href="/release_notes">release notes</a></p>
   <p><a href="#" onclick="hideShowInstallationText(document.getElementById('mac-install'))">(Hide)</a></p>
 </div>
 
 <div id="linux-install" class="installation-instructions">
   <h2>Linux Installation</h2>
-  <p>You must first install Java 8 or later. To test if you have Java installed, run this command from the command line: <code>java -version</code>.</p>
-  <p>You can install and download Java from <a href="http://java.com/">here</a>.</p>
-  <p>Download the file <code>triplea_{{ site.triplea-version }}_all_platforms.zip</code>.</p>
-  <p>Unzip it to any directory and execute the command <code>./triplea_unix.sh</code>.</p>
+  <p>Once the installer finishes downloading, make it executable (chmod +x ./TripleA_*unix.sh)</p>
+  <p>Now run the installer (./TripleA_...unix.sh)</p>
+  <p>Follow the installation prompts to complete the installation</p>
+  <br/>
+  <p>TripleA requires Java 8 or later to be installed</p>
+  <br />
+  <p">New to TripleA? Check out the <a href="../files/TripleA_RuleBook.pdf">Rulebook</a></p>
+  <p>Upgrading? See what has changed in the <a href="/release_notes">release notes</a></p>
   <p><a href="#" onclick="hideShowInstallationText(document.getElementById('linux-install'))">(Hide)</a></p>
 </div>


### PR DESCRIPTION
- Split windows download button between 32 bit and 64 bit
- Clean up download text in the download button
- Remove the prerelease links- Clean up the installation instructions, update the linux instructions, add help link to mac, prune down the windows section
- Clean up and update the installation instructions

Additional Changes:
- Remove direct download direct, if the download buttons do not work, the releases page will not be of any further help.
- Move the install4j credits to the top right and make the text smaller
- Move the rulebook and release notes to the OS specific instruction sections, the goal here being to unclutter the initial view and not have any links below the download buttons.

Before:
![before](https://cloud.githubusercontent.com/assets/12397753/18040293/f41808a8-6d60-11e6-9f4c-26250872d933.png)


After:
![after](https://cloud.githubusercontent.com/assets/12397753/18040288/e30f6ea2-6d60-11e6-8dbe-75f3629ade27.png)

