### PR TITLE
Correct a typo

### DIFF
--- a/community.html
+++ b/community.html
@@ -15,7 +15,7 @@ permalink: /community/
     <p>
       TripleA is an open source project hosted on <a href="https://github.com/triplea-game/triplea">Github</a>.
       Material on getting started as a map maker can be found on the 
-      <a href="https://github.com/triplea-maps/Projects">Github Map Projects page</a></li>
+      <a href="https://github.com/triplea-maps/Project">Github Map Project page</a></li>
     </p>
   </div>
   <div id="community_col" class="community_col_2 tawc">


### PR DESCRIPTION
It should be 
https://github.com/triplea-maps/Project

instead of 
https://github.com/triplea-maps/Projects

This solves issue #89 