### PR TITLE
'Old downloads' page

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -5,3 +5,5 @@ description: TripleA is a free online turn based strategy game and board game en
 markdown: kramdown
 
 game-version: 1.9.0.0.3199
+# size of the win64 download, won't be exact for each downloader, but will give a good benchmark 
+dl-size-mb: 52

--- a/download.html
+++ b/download.html
@@ -3,11 +3,9 @@ layout: page
 title: Download
 permalink: /download/
 ---
-  <p class="dl-install4j-credit"><small>Installer powered by <a href="http://www.ej-technologies.com/products/install4j/overview.html"><img src="../images/install4j_small.png" title="multi-platform installer builder" /></a></small></p>
-  <p class="dl-install4j-credit"><small>See what has changed in the <a href="/release_notes">release notes</a></small></p>
 
 
-<p>Select below to begin downloading the TripleA installer:</p>
+<p>Select below to begin downloading the TripleA installer ({{ site.dl-size-mb }} MB):</p>
 <a href="https://github.com/triplea-game/triplea/releases/download/{{ site.game-version }}/TripleA_{{ site.game-version }}_windows-64bit.exe"
        target="_blank" class="button dl-links" onclick="hideShowInstallationText(document.getElementById('windows-install'))">
   <img src="../images/operating-systems/windows100.png" />
@@ -32,9 +30,10 @@ permalink: /download/
 </a>
 
 </p>
-
-<p>Upgrading from 1.8.0.9? <a href="/upgrade_notes">read here for upgrade notes</a></p>
-<br/>
+  <p class="dl-install4j-credit"><small>See what has changed in the <a href="/release_notes">release notes</a></small></p>
+  <p class="dl-install4j-credit"><small>Upgrading from 1.8.0.9? <a href="/upgrade_notes">read here for upgrade notes</a></small></p>
+  <p class="dl-install4j-credit"><small>Download <a href="/old_downloads">old game engine versions here</a></small></p>
+  <p class="dl-install4j-credit"><small>Installer powered by <a href="http://www.ej-technologies.com/products/install4j/overview.html"><img src="../images/install4j_small.png" title="multi-platform installer builder" /></a></small></p>
 
 
 <div id="windows-install" class="installation-instructions">

--- a/download.html
+++ b/download.html
@@ -30,8 +30,8 @@ permalink: /download/
 </a>
 
 </p>
+  <p>Upgrading from 1.8.0.9? <a href="/upgrade_notes">read here for upgrade notes</a></p>
   <p class="dl-install4j-credit"><small>See what has changed in the <a href="/release_notes">release notes</a></small></p>
-  <p class="dl-install4j-credit"><small>Upgrading from 1.8.0.9? <a href="/upgrade_notes">read here for upgrade notes</a></small></p>
   <p class="dl-install4j-credit"><small>Download <a href="/old_downloads">old game engine versions here</a></small></p>
   <p class="dl-install4j-credit"><small>Installer powered by <a href="http://www.ej-technologies.com/products/install4j/overview.html"><img src="../images/install4j_small.png" title="multi-platform installer builder" /></a></small></p>
 

--- a/old_downloads.html
+++ b/old_downloads.html
@@ -1,0 +1,12 @@
+---
+layout: page
+title: Older TripleA Releases
+permalink: /old_downloads/
+---
+
+<h2>1.8.0.9</h2>
+<ul>
+  <li>Windows: <a href="https://github.com/triplea-game/triplea/releases/download/1.8.0.9/triplea_1_8_0_9_windows_installer.exe">triplea_1_8_0_9_windows_installer.exe</a> (306 MB)</li>
+  <li>Mac: <a href="https://github.com/triplea-game/triplea/releases/download/1.8.0.9/triplea_1_8_0_9_mac.dmg">triplea_1_8_0_9_mac.dmg</a> (357 MB)</li> 
+  <li>Unix: <a href="https://github.com/triplea-game/triplea/releases/download/1.8.0.9/triplea_1_8_0_9_all_platforms.zip">triplea_1_8_0_9_all_platforms.zip</a> (348 MB)</li>
+</ul>

--- a/upgrade_notes.md
+++ b/upgrade_notes.md
@@ -4,16 +4,7 @@ title: 1.8.0.9 Upgrade Notes
 permalink: /upgrade_notes/
 ---
 
-## Upgrading from 1.8.0.9 to 1.9
-
-### Game Engine
-The new 1.9 game engine will install to a new folder and can be played alongside a 1.8 installation.
-
-### Finishing 1.8 Saved Games
-For lobby games that were hosted on a bot server, those games will need to be finished on the 1.8 lobby. The 1.9 bots cannot load 1.8 saved games. Otherwise if you can do direct hosting, the 1.9 game engine can launch 1.8 saved games.
-
-### 1.8 Map Support for 1.9 
-Assuming windows, and the old 1.8 tripleA is installed to: "C:\Program Files\triplea", and your user home folder is "C:\Users\Jane"
-
-Copy any maps from "C:\Program Files\triplea\maps" to "C:\Users\Jane\triplea\maps". From there you can safely remove the old 1.8 game engine at: "C:\Program Files\triplea\".
+- TripleA 1.9 is now installed alongside TripleA 1.8, there is no need to remove 1.8 or any of its maps. 
+- You can run 1.8 to finish up any 1.8 saved games
+- You will need to redownload maps in 1.9
 


### PR DESCRIPTION
- moved around links on download page to bottom right and added a link for the 'old downloads' page
- added an 'old downloads' page
- simplified the upgrade notes


Download page before:
![before](https://cloud.githubusercontent.com/assets/12397753/18818784/07c21816-8338-11e6-90f6-ec90c167f205.png)

Download page after:
![after](https://cloud.githubusercontent.com/assets/12397753/18818810/ab078b00-8338-11e6-936c-8b70d596f116.png)


New 'old downloads' page:
![old_downloads](https://cloud.githubusercontent.com/assets/12397753/18818783/07c15692-8338-11e6-90e1-9fff451dbb33.png)
