### PR TITLE
Add import order formatter configuration link

### DIFF
--- a/dev_docs/dev/code_format.md
+++ b/dev_docs/dev/code_format.md
@@ -11,6 +11,7 @@ Please import these IDE formatter templates:
 
 - [https://github.com/triplea-game/triplea/blob/master/eclipse/format/triplea_java_eclipse_format_style.xml](https://github.com/triplea-game/triplea/blob/master/eclipse/format/triplea_java_eclipse_format_style.xml)
 - [https://github.com/triplea-game/triplea/blob/master/eclipse/format/triplea_java_eclipse_cleanup.xml](https://github.com/triplea-game/triplea/blob/master/eclipse/format/triplea_java_eclipse_cleanup.xml)
+- [https://github.com/triplea-game/triplea/blob/master/eclipse/format/triplea.importorder](https://github.com/triplea-game/triplea/blob/master/eclipse/format/triplea.importorder)
 
 ### Installing the formatter in IntelliJ
 1. Import the xml into intellij's java code style, and then choose it as your style

--- a/dev_docs/dev/code_format.md
+++ b/dev_docs/dev/code_format.md
@@ -9,8 +9,8 @@ For the most part, we are following [Google java style](http://google.github.io/
 ## Format
 Please import these IDE formatter templates:
 
-- [https://github.com/triplea-game/triplea/blob/master/triplea_java_eclipse_format_style.xml](https://github.com/triplea-game/triplea/blob/master/triplea_java_eclipse_format_style.xml)
-- [https://github.com/triplea-game/triplea/blob/master/triplea_java_eclipse_cleanup.xml](https://github.com/triplea-game/triplea/blob/master/triplea_java_eclipse_cleanup.xml)
+- [https://github.com/triplea-game/triplea/blob/master/eclipse/format/triplea_java_eclipse_format_style.xml](https://github.com/triplea-game/triplea/blob/master/eclipse/format/triplea_java_eclipse_format_style.xml)
+- [https://github.com/triplea-game/triplea/blob/master/eclipse/format/triplea_java_eclipse_cleanup.xml](https://github.com/triplea-game/triplea/blob/master/eclipse/format/triplea_java_eclipse_cleanup.xml)
 
 ### Installing the formatter in IntelliJ
 1. Import the xml into intellij's java code style, and then choose it as your style


### PR DESCRIPTION
This PR adds a link to the Eclipse import order formatter configuration (which was added in triplea-game/triplea#1589) to the developer docs code format page.

It also fixes the broken links to the other Eclipse formatter templates.