### PR TITLE
Remove statement that Tutorial map is installed by default

### DIFF
--- a/help/downloading-maps.md
+++ b/help/downloading-maps.md
@@ -4,7 +4,7 @@ title: Help&colon; Downloading Maps
 permalink: /downloading_maps/
 ---
 
-As of TripleA 1.9, downloading maps has become much easier. Since only the Tutorial comes by default with the engine, it is imperative that you download some maps and get started playing right away.
+As of TripleA 1.9, downloading maps has become much easier. Since no maps come by default with the engine, it is imperative that you download some maps and get started playing right away.
 
 
 


### PR DESCRIPTION
This PR removes a statement indicating the Tutorial map is installed by default, which is no longer true in light of triplea-game/triplea#1585.

Because triplea-game/triplea#1585 is not yet in a release version, it may be appropriate to hold off on merging this PR until the next engine release.

@ron-murhammer @DanVanAtta 