### PR TITLE
Added maps feedback page with form

### DIFF
--- a/maps.md
+++ b/maps.md
@@ -6,6 +6,10 @@ permalink: /maps/
 
 TripleA is very versatile and can be used for scenarios from Hannibal crossing the Alps to very futuristic and modern time periods. Here are a few examples of the most popular maps on TripleA. (A comprehensive download list can be found inside TripleA using the 'Download Maps' feature.)
 
+TripleA will very soon have a new maps listing that will display all of its maps with ratings on playability, recommended settings, and more. Giving feedback about your favorite maps will help support your favorite maps on TripleA.
+
+[Give Maps feedback]({{ "/maps/feedback/" | prepend: site.baseurl }})
+
 ## Big World
 
 ![Big World Map]({{ "/images/maps/BigWorld.png" | prepend: site.baseurl }})

--- a/maps/feedback.md
+++ b/maps/feedback.md
@@ -1,0 +1,9 @@
+---
+layout: page
+title: Maps Feedback
+permalink: /maps/feedback/
+---
+
+TripleA maps vary greatly in their playtime, number of players, balance, complexity, AI compatibility, and recommended settings. The following form will allow for user input into these ratings, which will be displayed on the individual maps pages or perhaps on the maps listing to help those thinking about downloading these maps.
+
+<iframe src="https://docs.google.com/forms/d/e/1FAIpQLScBWnjsRIb62wld_-QY-5W9CtvDD3iNpZ3f1HYLwfS-Piyqyw/viewform?embedded=true#responses" width="760" height="500" frameborder="0" marginheight="0" marginwidth="0">Loading...</iframe>


### PR DESCRIPTION
I've added [this form](https://goo.gl/forms/ZqQKDf2MJ3GKenVN2) for giving maps feedback to the website on the suggestion of @RoiEXLab and linked to it from the existing maps page. The thought is that the existing maps page will be eventually deleted, getting rid of the anachronism once the new maps page is live. I'll think up a way of integrating the form into the new maps page in the meantime. This will help us get more information for the maps listing.