### PR TITLE
Replace " with ' inside html attributes

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -3,9 +3,9 @@
     <div id="footer_col_3" class="footer_col about">
       <h3>About</h3>
       <ul>
-        <li><a href="{{ "/about" | prepend: site.baseurl }}">About TripleA</a></li>
-        <li><a href="{{ "/about/#features" | prepend: site.baseurl }}">Features</a></li>
-        <li><a href="{{ "/maps" | prepend: site.baseurl }}">Maps</a></li>
+        <li><a href="{{ '/about' | prepend: site.baseurl }}">About TripleA</a></li>
+        <li><a href="{{ '/about/#features' | prepend: site.baseurl }}">Features</a></li>
+        <li><a href="{{ '/maps' | prepend: site.baseurl }}">Maps</a></li>
         <li><a href="http://www.gnu.org/copyleft/gpl.html">License</a></li>
       </ul>
     </div>

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -6,11 +6,11 @@
   <title>{% if page.title %}{{ page.title }}{% else %}{{ site.title }}{% endif %}</title>
   <meta name="description" content="{% if page.excerpt %}{{ page.excerpt | strip_html | strip_newlines | truncate: 160 }}{% else %}{{ site.description }}{% endif %}">
 
-  <link rel="stylesheet" href="{{ "/css/main.css" | prepend: site.baseurl }}">
-  <link rel="stylesheet" href="{{ "/css/slideshow.css" | prepend: site.baseurl }}">
-  <link rel="stylesheet" href="{{ "/css/fonts/stylesheet.css" | prepend: site.baseurl }}" type="text/css">
+  <link rel="stylesheet" href="{{ '/css/main.css' | prepend: site.baseurl }}">
+  <link rel="stylesheet" href="{{ '/css/slideshow.css' | prepend: site.baseurl }}">
+  <link rel="stylesheet" href="{{ '/css/fonts/stylesheet.css' | prepend: site.baseurl }}" type="text/css">
   <link rel="canonical" href="{{ page.url | replace:'index.html','' | prepend: site.baseurl | prepend: site.url }}">
 
-  <link rel="shortcut icon" href="{{ "/images/favicon.ico" | prepend: site.baseurl }}" type="image/x-icon">
-  <link rel="icon" href="{{ "/images/favicon.ico" | prepend: site.baseurl }}" type="image/x-icon">
+  <link rel="shortcut icon" href="{{ '/images/favicon.ico' | prepend: site.baseurl }}" type="image/x-icon">
+  <link rel="icon" href="{{ '/images/favicon.ico' | prepend: site.baseurl }}" type="image/x-icon">
 </head>

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -3,17 +3,17 @@
     <nav class="site-nav">
       <ul id="menu">
         <li>
-          <a href="{{ "/" | prepend: site.baseurl }}"><img src="{{ "/images/icon_menu.png" | prepend: site.baseurl }}" alt="TripleA Icon"></a>
+          <a href="{{ '/' | prepend: site.baseurl }}"><img src="{{ '/images/icon_menu.png' | prepend: site.baseurl }}" alt="TripleA Icon"></a>
         </li>
         <li>
-          <h1><a href="{{ "/" | prepend: site.baseurl }}">TripleA</a></h1>
+          <h1><a href="{{ '/' | prepend: site.baseurl }}">TripleA</a></h1>
         </li>
-        <li class="menu-items"><a href="{{ "/download" | prepend: site.baseurl }}">Download</a></li>
-        <li class="menu-items"><a href="{{ "/community" | prepend: site.baseurl }}">Community</a></li>
-        <li class="menu-items"><a href="{{ "/maps" | prepend: site.baseurl }}">Maps</a></li>
-        <li class="menu-items"><a href="{{ "/screenshots" | prepend: site.baseurl }}">Screenshots</a></li>
-        <li class="menu-items"><a href="{{ "/help" | prepend: site.baseurl }}">Help &amp; Rules</a></li>
-        <li class="menu-items"><a href="{{ "/about" | prepend: site.baseurl }}">About</a></li>
+        <li class="menu-items"><a href="{{ '/download' | prepend: site.baseurl }}">Download</a></li>
+        <li class="menu-items"><a href="{{ '/community' | prepend: site.baseurl }}">Community</a></li>
+        <li class="menu-items"><a href="{{ '/maps' | prepend: site.baseurl }}">Maps</a></li>
+        <li class="menu-items"><a href="{{ '/screenshots' | prepend: site.baseurl }}">Screenshots</a></li>
+        <li class="menu-items"><a href="{{ '/help' | prepend: site.baseurl }}">Help &amp; Rules</a></li>
+        <li class="menu-items"><a href="{{ '/about' | prepend: site.baseurl }}">About</a></li>
         <li class="menu-items"><a href="https://forums.triplea-game.org">Forums</a></li>
       </ul>
     </nav>

--- a/feed.xml
+++ b/feed.xml
@@ -7,7 +7,7 @@ layout: null
     <title>{{ site.title | xml_escape }}</title>
     <description>{{ site.description | xml_escape }}</description>
     <link>{{ site.url }}{{ site.baseurl }}/</link>
-    <atom:link href="{{ "/feed.xml" | prepend: site.baseurl | prepend: site.url }}" rel="self" type="application/rss+xml"/>
+    <atom:link href="{{ '/feed.xml' | prepend: site.baseurl | prepend: site.url }}" rel="self" type="application/rss+xml"/>
     <pubDate>{{ site.time | date_to_rfc822 }}</pubDate>
     <lastBuildDate>{{ site.time | date_to_rfc822 }}</lastBuildDate>
     <generator>Jekyll v{{ jekyll.version }}</generator>

--- a/index.html
+++ b/index.html
@@ -16,7 +16,7 @@ layout: default
       <p>Community built maps, Axis and Allies game rules:</p>
     <br>
     <span class="download">
-      <a href="{{ "/download" | prepend: site.baseurl }}" class="button">Download TripleA</a>
+      <a href="{{ '/download' | prepend: site.baseurl }}" class="button">Download TripleA</a>
     </span>
       <p>100% open source, community run, free to play game</p>
       <p>Multiplayer and single player game options</p>

--- a/maps/all.html
+++ b/maps/all.html
@@ -3,14 +3,14 @@ layout: page
 title: All Maps
 permalink: /maps-list/all/
 ---
-<p><a href="{{ "/maps-list" | prepend: site.baseurl }}">Maps</a> |  <a href="{{ "/maps-list/categories" | prepend: site.baseurl }}">Categories</a> | <a href="{{ "/maps-list/mods" | prepend: site.baseurl }}">Mods and Skins</a> | <a href="{{ "/maps-list/all" | prepend: site.baseurl }}">All</a></p>
+<p><a href="{{ '/maps-list' | prepend: site.baseurl }}">Maps</a> |  <a href="{{ '/maps-list/categories' | prepend: site.baseurl }}">Categories</a> | <a href="{{ '/maps-list/mods' | prepend: site.baseurl }}">Mods and Skins</a> | <a href="{{ '/maps-list/all' | prepend: site.baseurl }}">All</a></p>
 <div class="maps-col-wrapper">
   {% for map in site.data.triplea_maps %}
   {% if map.mapType != "MAP_TOOL" %}
   <div class="maps_col" data-map-name="{{ map.mapName }}">
     <h3>{{ map.mapName }}</h3>
       <p>
-        <a class="maps_col_button button" href="{{ "/docs/downloading_maps" | prepend: site.baseurl }}">Download</a>
+        <a class="maps_col_button button" href="{{ '/docs/downloading_maps' | prepend: site.baseurl }}">Download</a>
       </p>
   </div>
   {% endif %}

--- a/maps/categories.html
+++ b/maps/categories.html
@@ -3,7 +3,7 @@ layout: page
 title: Map Categories
 permalink: /maps-list/categories/
 ---
-<p><a href="{{ "/maps-list" | prepend: site.baseurl }}">Maps</a> |  <a href="{{ "/maps-list/categories" | prepend: site.baseurl }}">Categories</a> | <a href="{{ "/maps-list/mods" | prepend: site.baseurl }}">Mods and Skins</a> | <a href="{{ "/maps-list/all" | prepend: site.baseurl }}">All</a></p>
+<p><a href="{{ '/maps-list' | prepend: site.baseurl }}">Maps</a> |  <a href="{{ '/maps-list/categories' | prepend: site.baseurl }}">Categories</a> | <a href="{{ '/maps-list/mods' | prepend: site.baseurl }}">Mods and Skins</a> | <a href="{{ '/maps-list/all' | prepend: site.baseurl }}">All</a></p>
 <div class="maps-col-section high_quality">
 <h2 class="section-title">High Quality Maps</h2>
 {% for map in site.data.triplea_maps %}
@@ -11,7 +11,7 @@ permalink: /maps-list/categories/
   <div class="maps_col" data-map-name="{{ map.mapName }}">
     <h3>{{ map.mapName }}</h3>
       <p>
-        <a class="maps_col_button button" href="{{ "/docs/downloading_maps" | prepend: site.baseurl }}">Download</a>
+        <a class="maps_col_button button" href="{{ '/docs/downloading_maps' | prepend: site.baseurl }}">Download</a>
       </p>
   </div>
 {% endif %}
@@ -24,7 +24,7 @@ permalink: /maps-list/categories/
   <div class="maps_col" data-map-name="{{ map.mapName }}">
     <h3>{{ map.mapName }}</h3>
       <p>
-        <a class="maps_col_button button" href="{{ "/docs/downloading_maps" | prepend: site.baseurl }}">Download</a>
+        <a class="maps_col_button button" href="{{ '/docs/downloading_maps' | prepend: site.baseurl }}">Download</a>
       </p>
   </div>
 {% endif %}
@@ -37,7 +37,7 @@ permalink: /maps-list/categories/
   <div class="maps_col" data-map-name="{{ map.mapName }}">
     <h3>{{ map.mapName }}</h3>
       <p>
-        <a class="maps_col_button button" href="{{ "/docs/downloading_maps" | prepend: site.baseurl }}">Download</a>
+        <a class="maps_col_button button" href="{{ '/docs/downloading_maps' | prepend: site.baseurl }}">Download</a>
       </p>
   </div>
 {% endif %}

--- a/maps/index.html
+++ b/maps/index.html
@@ -3,7 +3,7 @@ layout: page
 title: Maps
 permalink: /maps-list/
 ---
-<p><a href="{{ "/maps-list" | prepend: site.baseurl }}">Maps</a> |  <a href="{{ "/maps-list/categories" | prepend: site.baseurl }}">Categories</a> | <a href="{{ "/maps-list/mods" | prepend: site.baseurl }}">Mods and Skins</a> | <a href="{{ "/maps-list/all" | prepend: site.baseurl }}">All</a></p>
+<p><a href="{{ '/maps-list' | prepend: site.baseurl }}">Maps</a> |  <a href="{{ '/maps-list/categories' | prepend: site.baseurl }}">Categories</a> | <a href="{{ '/maps-list/mods' | prepend: site.baseurl }}">Mods and Skins</a> | <a href="{{ '/maps-list/all' | prepend: site.baseurl }}">All</a></p>
 <div class="maps-col-wrapper">
   <h2 class="section-title">Featured Maps</h2>
   {% for map in site.data.triplea_maps %}
@@ -11,7 +11,7 @@ permalink: /maps-list/
   <div class="maps_col" data-map-name="{{ map.mapName }}">
     <h3>{{ map.mapName }}</h3>
       <p>
-        <a class="maps_col_button button" href="{{ "/docs/downloading_maps" | prepend: site.baseurl }}">Download</a>
+        <a class="maps_col_button button" href="{{ '/docs/downloading_maps' | prepend: site.baseurl }}">Download</a>
       </p>
   </div>
   {% endif %}

--- a/maps/mods.html
+++ b/maps/mods.html
@@ -3,7 +3,7 @@ layout: page
 title: Mods and Skins
 permalink: /maps-list/mods/
 ---
-<p><a href="{{ "/maps-list" | prepend: site.baseurl }}">Maps</a> |  <a href="{{ "/maps-list/categories" | prepend: site.baseurl }}">Categories</a> | <a href="{{ "/maps-list/mods" | prepend: site.baseurl }}">Mods and Skins</a> | <a href="{{ "/maps-list/all" | prepend: site.baseurl }}">All</a></p>
+<p><a href="{{ '/maps-list' | prepend: site.baseurl }}">Maps</a> |  <a href="{{ '/maps-list/categories' | prepend: site.baseurl }}">Categories</a> | <a href="{{ '/maps-list/mods' | prepend: site.baseurl }}">Mods and Skins</a> | <a href="{{ '/maps-list/all' | prepend: site.baseurl }}">All</a></p>
 <div class="maps-col-section mod">
 <h2 class="section-title">Map Mods</h2>
 {% for map in site.data.triplea_maps %}
@@ -11,7 +11,7 @@ permalink: /maps-list/mods/
   <div class="maps_col" data-map-name="{{ map.mapName }}">
     <h3>{{ map.mapName }}</h3>
       <p>
-        <a class="maps_col_button button" href="{{ "/docs/downloading_maps" | prepend: site.baseurl }}">Download</a>
+        <a class="maps_col_button button" href="{{ '/docs/downloading_maps' | prepend: site.baseurl }}">Download</a>
       </p>
   </div>
 {% endif %}
@@ -24,7 +24,7 @@ permalink: /maps-list/mods/
   <div class="maps_col" data-map-name="{{ map.mapName }}">
     <h3>{{ map.mapName }}</h3>
       <p>
-        <a class="maps_col_button button" href="{{ "/docs/downloading_maps" | prepend: site.baseurl }}">Download</a>
+        <a class="maps_col_button button" href="{{ '/docs/downloading_maps' | prepend: site.baseurl }}">Download</a>
       </p>
   </div>
 {% endif %}


### PR DESCRIPTION
Using double quotes inside attribute declarations breaks the syntax highlighting inside attribute definitions e.g.: `<img src="{{ "/something/something" | prepend: site.baseurl }}">` using single quotes works absolutely fine and doesn't break syntax highlighting