### PR TITLE
Fix footer on maps lists pages

### DIFF
--- a/_sass/_base.scss
+++ b/_sass/_base.scss
@@ -272,9 +272,11 @@ a:hover {
  * Maps Page
  */
 
-#maps-col-wrapper {
-  width: 50%;
-  float: left;
+.maps-col-wrapper::after, .maps-col-section::after {
+   content: " ";
+   display: block;
+   height: 0;
+   clear: both;
 }
 
 .maps_col {


### PR DESCRIPTION
Before:
![www triplea-game org-maps-list-categories-](https://cloud.githubusercontent.com/assets/8350879/26597735/44e3aef0-4573-11e7-8672-494ae7072f7a.png)
After:
![localhost-4000-maps-list-categories-](https://cloud.githubusercontent.com/assets/8350879/26597759/54a2bb9c-4573-11e7-9664-6d1ba8af5d44.png)
(It's actually worse if you have a tiny monitor)