### PR TITLE
Migrate 'issue labelling', copy/pasted from triplea-game wiki

### DIFF
--- a/dev_docs/dev/issues_labels.md
+++ b/dev_docs/dev/issues_labels.md
@@ -1,0 +1,50 @@
+Labels are tags that help categorize issues. 
+Admins can create or remove them to help categorize the issue queue at any given time.
+They are pretty fluid as new categorizes of topics come up.
+Below is a listing explaining what each label should mean.
+
+
+### Bug Backlog
+A code defect, something that is not working like it should
+
+### Close Pending Confirmation
+Waiting state before closing a problem to verify the issue has been addressed. This can mean that current conversation in the issue seems to be settled, or for code bugs it could mean that a PR is in flight with a code fix (in-flight means the code update has been tested and submitted, but not yet necessarily merged to master, the main game branch)
+
+### Discussion
+Marks an issue where the outcome is a discussion. There might be a decision to be made, more information desired, or a brain storming session about how a feature or process should work.
+
+### Feature Backlog
+A request for a new feature or an enhancement to existing functionality.
+
+### Game Rules/Play
+Tag to indicate the issue is about game rules, the mechanics of how the game is played.
+
+### Infra/Code Backlog
+A task or topic relating to the development coding infrastructure and code deployment pipeline.
+
+###  Map Bug Backlog
+Problems related to maps.
+
+### Not Fixed / Ice Box
+Issue was closed without adequate action. To be effective in working the ticket queue down, we need to keep things actionable and 'snappy'. Ideally we would fix all problems, but at some point, it's better to close an issue and just let it come up again. Important problems will have a tendency to come back up. Issues labelled with this are an admission of defeat, but it's also a way to focus effort away from potentially one-off problems to the larger issues that impact users more often.
+
+### Performance
+Topic related to game performance. This will generally be a 'this is a slow' type of ticket
+
+### Process
+Indicates a topic that is related just to process. The ticket will talk about the 'how' for any given topic. Generally these will be discussion topic, as we will be discussing strategies of how to accomplish / solve recurring tasks.
+
+### UI Related
+Ticket is related to the in-game graphics (user interface). Things like, 'button is in wrong location', or 'text size is small'.
+
+### Major Bug
+Indicates a high impacting bug, something we probably should fix before other bugs. For these issues, we cannot do something important, or the game is unplayable/corrupted.
+
+###  WarClub Project
+Grouping label for 'warclub project'. Essentially a project to consolidate and improve our website(s). As part of this, we need to make a few decisions about where various infrastructure components will go.
+
+
+## Issue labeling discussions and tickets
+
+* https://github.com/triplea-game/triplea/issues/1059
+* https://github.com/triplea-game/triplea/issues/1391


### PR DESCRIPTION
From: https://github.com/triplea-game/triplea/wiki/Issue-Labelling

Reason: we've been trying a few different ways to consolidate documentation, the latest effort was to get everything on the github.io website so it was publicly accessible. It does seem like dev documentation may move back to the triple-game/triplea code repo, but in the meantime we should complete the migration away from triplea-game wiki for any permanent documentation (wiki was decided it would be best for ephemeral lists, eg: feature requests, legacy features we are working out. Basically any type of long lived tracking list would be a candidate for wiki)