### PR TITLE
Add missing permalink (#221)

### DIFF
--- a/screenshots.md
+++ b/screenshots.md
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: Screenshots
+permalink: /screenshots/
 ---
 Open the images below in a new tab to see full size
 


### PR DESCRIPTION
Experimental fix for #221.  I'm not sure if this is required because the current version runs fine for me locally without the `permalink`.  I tested it locally to make sure the additional property didn't cause any issues.