### PR TITLE
Fix broken link

### DIFF
--- a/dev_docs/dev/builder_bot.md
+++ b/dev_docs/dev/builder_bot.md
@@ -15,7 +15,7 @@ An admin owned account used for automated build tasks that require repository wr
   - Description: This key allows Travis to push to github releases. It is set up by the
       Travis ruby set up program when first configuring travis with TripleA.
 - Map Push Key
-  - Usage: [Code Snippet](https://github.com/triplea-game/triplea/blob/master/.travis/push_maps_yaml#L10)
+  - Usage: [Code Snippet](https://github.com/triplea-game/triplea/blob/master/.travis/push_maps#L8)
   - Description: Write-Access to TripleA github.io website repo to add map description files
 - Push Tag
   - Usage: [Code Snippet](https://github.com/triplea-game/triplea/blob/master/.travis/push_tag#L13)


### PR DESCRIPTION
Latest Travis build reported a broken link:

```
$ java -jar ./.binary/link-checker/build/libs/link-checker.jar -s http://localhost:4000 -d _site/ -if ./.travis/ignore-list.txt
Processing /home/travis/build/triplea-game/triplea-game.github.io/_site/map/zombieland/index.html    

Checking http://localhost:4000/map/triplea-map-creator/
Checking https://codeload.github.com/triplea-maps/zombieland/zip/master

Errors:

Link 'https://github.com/triplea-game/triplea/blob/master/.travis/push_maps_yaml#L10' returned code 404
	Affected Files:
		/home/travis/build/triplea-game/triplea-game.github.io/_site/dev_docs/dev/builder_bot/index.html

Warnings:

Link 'https://www.paypal.com/donate?token=E0OFkOh-qNhfT9j4U7Z2ckV6NFRWjXT1k5ACbrU3_ZCZudhkG8ZA40Z7X9KCP1lwRHIj30' was redirected permanently to 'https://www.paypal.com/donate/?token=E0OFkOh-qNhfT9j4U7Z2ckV6NFRWjXT1k5ACbrU3_ZCZudhkG8ZA40Z7X9KCP1lwRHIj30' Consider updating this link
	Affected Files:
		/home/travis/build/triplea-game/triplea-game.github.io/_site/sponsors/index.html

The command "java -jar ./.binary/link-checker/build/libs/link-checker.jar -s http://localhost:4000 -d _site/ -if ./.travis/ignore-list.txt" exited with 1.
```

This file was renamed in triplea-game/triplea@f687bc9.