### PR TITLE
Update download page links. Reduce some of the page text, add a link …

### DIFF
--- a/download.html
+++ b/download.html
@@ -27,7 +27,7 @@ permalink: /download/
 <p><a href="{{ '/release_notes/' | prepend: site.baseurl }}">Release Notes</a></p>
 <p><a id="sourceLink" href="https://github.com/triplea-game/triplea/releases/latest">Source Code</a></p>
 <p><a href="{{ '/old_downloads/' | prepend: site.baseurl }}">Previous TripleA Releases</a></p>
-<p><a id="sourceLink" href="https://github.com/triplea-game/triplea/releases/">Early Release Download</a></p>
+<p><a href="https://github.com/triplea-game/triplea/releases/">Early Release Download</a></p>
 
 
 <div id="windows-install" class="installation-instructions">

--- a/download.html
+++ b/download.html
@@ -4,7 +4,7 @@ title: Download
 permalink: /download/
 ---
 <p class="dl-install4j-credit"><small>Installer powered by <a href="http://www.ej-technologies.com/products/install4j/overview.html"><img src="../images/install4j_small.png" title="multi-platform installer builder" alt="Install4j Icon"></a></small></p>
-<p>Select below to begin downloading the TripleA installer (<span id="dl-size-mb">N/A</span> MB):</p>
+<p>Download the TripleA installer (<span id="dl-size-mb">N/A</span> MB):</p>
 
 <a id="win64" href="https://github.com/triplea-game/triplea/releases/latest" target="_blank" class="button dl-links" onclick="hideShowInstallationText(document.getElementById('windows-install'))">
   <img src="../images/operating-systems/windows100.png" alt="Windows Icon">
@@ -23,10 +23,12 @@ permalink: /download/
   <p>TripleA for Linux</p>
 </a>
 
-<p>Upgrading from 1.8.0.9? <a href="{{ '/upgrade_notes/' | prepend: site.baseurl }}">read here for upgrade notes</a></p>
-<p>See what has changed in the <a href="{{ '/release_notes/' | prepend: site.baseurl }}">release notes</a></p>
-<p>Download <a href="{{ '/old_downloads/' | prepend: site.baseurl }}">previous TripleA releases here</a></p>
-<p>Download <a id="sourceLink" href="https://github.com/triplea-game/triplea/releases/latest">Source Code from Github Releases</a></p>
+<h2>Additional Links</h2>
+<p><a href="{{ '/release_notes/' | prepend: site.baseurl }}">Release Notes</a></p>
+<p><a id="sourceLink" href="https://github.com/triplea-game/triplea/releases/latest">Source Code</a></p>
+<p><a href="{{ '/old_downloads/' | prepend: site.baseurl }}">Previous TripleA Releases</a></p>
+<p><a id="sourceLink" href="https://github.com/triplea-game/triplea/releases/">Early Release Download</a></p>
+
 
 <div id="windows-install" class="installation-instructions">
   <h2>Windows Installation</h2>


### PR DESCRIPTION
…to 'early releases'

- Also removed the 'upgrading from 1.8.0.9' link.

After:
![updated](https://user-images.githubusercontent.com/12397753/28747928-8e7ae608-745f-11e7-971e-ad1cf1e5be7b.png)


Before:
![before](https://user-images.githubusercontent.com/12397753/28747936-abf06ce4-745f-11e7-887d-7cea877fcc42.png)


