### PR TITLE
Update permanently redirected links

### DIFF
--- a/dev_docs/engine_admin/index.md
+++ b/dev_docs/engine_admin/index.md
@@ -4,6 +4,6 @@ title: Adminsitrative Documentation
 permalink: /dev_docs/engine_admin/
 ---
 
-- [Build Pipeline]({{ "/dev_docs/admin/build_pipeline" | prepend: site.baseurl }})
-- [How to Release]({{ "/dev_docs/admin/how_to_release" | prepend: site.baseurl }})
-- [Issue Management]({{ "/dev_docs/admin/issue_management" | prepend: site.baseurl }})
+- [Build Pipeline]({{ "/dev_docs/admin/build_pipeline/" | prepend: site.baseurl }})
+- [How to Release]({{ "/dev_docs/admin/how_to_release/" | prepend: site.baseurl }})
+- [Issue Management]({{ "/dev_docs/admin/issue_management/" | prepend: site.baseurl }})

--- a/dev_docs/older/game_playing_guide.html
+++ b/dev_docs/older/game_playing_guide.html
@@ -98,7 +98,7 @@ root: /dev_docs/
 	For those persons who do not have built-in zip file support of do not wish to use
 	Windows's zip file support, can use several other programs. There are several freeware
 	programs such as <a href="http://www.winzip.com" target="_blank">WinZip</a> and
-	<a href="http://www.rarlabs.com" target="_blank">WinRAR</a> that allow you to zip and
+	<a href="http://www.rarlab.com" target="_blank">WinRAR</a> that allow you to zip and
 	unzip files (and more!). So installing either one of those packages will allow you
 	to unzip the TripleA zip file.
 </p>


### PR DESCRIPTION
`link-checker` indicated these URLs were being permanently redirected in the latest build, so this PR simply updates them to the redirected URL.

There was one additional link marked as permanently redirected:

```
Link 'https://www.paypal.com/donate?token=ku-pSEpS_Tq6-qHJl4QJP81ZuyCKxwTcs5uEgPnk-kOpl8AjJ56lwriJ4KhAflsv94p3W0&country.x=US&locale.x=' was redirected permanently to 'https://www.paypal.com/donate/?token=ku-pSEpS_Tq6-qHJl4QJP81ZuyCKxwTcs5uEgPnk-kOpl8AjJ56lwriJ4KhAflsv94p3W0&country.x=US&locale.x=' Consider updating this link
	Affected Files:
		/home/travis/build/ssoloff/triplea-game-triplea-game.github.io/_site/sponsors/index.html
```

but I couldn't locate it in the sources.  The only PayPal link I could find looks completely different (in `sponsors.md`):

```
https://www.paypal.com/cgi-bin/webscr?item_name=Donation+to+TripleA&cmd=_donations&business=veqryn@hotmail.com&Z3JncnB0=
```