### PR TITLE
About.md edits

### DIFF
--- a/about.md
+++ b/about.md
@@ -4,26 +4,23 @@ permalink: /about/
 title: About
 ---
 
-TripleA is a networked open source strategy gaming engine that allows for customized user editable maps and rules. Typically game rules are based upon Axis and Allies rules.
+
+TripleA is a networked open source strategy gaming engine that allows for Axis and Allies style rules and customized user editable maps.
 
 
-TripleA is released under the GNU Public License (GPL). This license means you are free to distribute this work and any derivatives you make from this work either commercially or non-commercially but only under the terms of the GPL (i.e. must make source code available to your users and must allow your users themselves to freely distribute the work and any further derivatives under the GPL).
+## TripleA History
 
-## About TripleA
-
-TripleA was started in Oct 2001 by an unemployed Sean Bridges who was looking for a way to build up his resume after the end of the tech bubble. Unfortunately Sean was too successful, and soon after the 0.1 release (which he managed to demo in a job interview) he secured gainful employment.
+TripleA was started in Oct 2001 by an unemployed Sean Bridges looking for a way to build up his resume after the end of the tech bubble. Using the 0.1 release as a demo in a job interview, Sean was soon employed.
 
 Sean working full time dramatically slowed the progress of TripleA for a long time. Numerous people made contributions to the project, including both DMA02 and IronCross from a very early stage, but with Sean doing most of the development, and with the limited early graphics, the project did not improve dramatically.
 
 TripleA would have continued on this slow trajectory, but two events occurring relatively closely revitalized the project. The first was the contribution by Logan of new graphics, giving the game a better look and feel. The second event was the release of the revised map and rules. With no competing real time game, interest in TripleA increased.
 
-TripleA 0.3.1 was probably the first version that was really playable in networked mode. And since then, increasing community interest, and with great contributions from a number of people, TripleA continues to grow and prosper.
+TripleA 0.3.1 was one of the first versions that was really playable in networked mode. Since then, TripleA gained a very active online player base.
 
-<a id="features">
 
-## TripleA Features
+## Game Modes:
 
-### Game Modes:
 * Team play, free for all, 1v1
 * Single player vs. AI, and hot-seat mode
 * Multiplayer using Play By Email (pbem)
@@ -31,11 +28,11 @@ TripleA 0.3.1 was probably the first version that was really playable in network
 * Multiplayer using a free online lobby (with support for things like booting, moderators, etc.)
 (TripleA's main purpose is for online play against other people, and it was created as such. To truly experience TripleA, you must try out the online lobby.)
 
-### Secure:
+## Secure:
 * Online games use a dice server which sends encrypted dice to both players at the same time.
 * Save Games are encrypted also (you can save a multiplayer game and pick it up at a later time).
 
-### Special Game Features:
+## Special Game Features:
 * Can Save at any moment
 * Player disconnect generate a savegame, so that you can rehost without losing any time or information, and can even replace the player who dropped if need be
 * Can view game history at any moment, showing not just what happened and the dice rolled, but also how the entire board/map looked
@@ -48,7 +45,7 @@ TripleA 0.3.1 was probably the first version that was really playable in network
 * Dice and Game statistics, shown in game and can be exported to files
 * Ability to set different victory condition
 
-### Huge Variety:
+## Huge Variety:
 Though the majority of our maps and games revolve around World War II, we also have:
 * World War I games
 * World War 3 games, like the Cold War or future conflicts
@@ -58,7 +55,12 @@ Though the majority of our maps and games revolve around World War II, we also h
 * Abstract Maps, like things on hex maps
 * Futuristic games, like Star Wars, or Zombieland
 
-### User Created Content:
+## User Created Content:
 * TripleA contains the ability to create and download user made maps.
 * Many of these maps, like "New World Order" have generated quite a following.
 * Rules can vary by map, depending on what the map creator wants.
+
+## Software Licensing
+
+TripleA is released under the GNU Public License (GPL). This license means you are free to distribute this work and any derivatives you make from this work either commercially or non-commercially but only under the terms of the GPL (i.e. must make source code available to your users and must allow your users themselves to freely distribute the work and any further derivatives under the GPL).
+


### PR DESCRIPTION
- give licensing its own section and drop to bottom. The location is more in consideration of the other topics we have in the page, they seem to belong together before licensing info.
- clean up first few paragraphs a bit, shorten the text, reword
- update heads, drop the sub-section for TripleA features, the subsections can be their own h2 headers. This is to simplify the structure of the page a bit more.

Still a bit more to be done for future iterations:
-  the newly labelled history section does not seem very complete, the history info ends with a future sounding note, but from a perspective that ends in around 2005.
- We also still have similar info on other pages, some de-duplication would be worthwhile, it's also not clear if all of the content on 'about.md' should live there.