### PR TITLE
Add link to map lists

### DIFF
--- a/_layouts/map.html
+++ b/_layouts/map.html
@@ -7,7 +7,6 @@ layout: default
 <img src="{% if page.img %}{{ page.img }}{% else %}{{ '/images/missing_map.png' | prepend: site.baseurl }}{% endif %}" alt="Map Thumbnail">
 {{ content }}
 <br>
-<a href="{{ page.downloadUrl }}" class="button">Manual Download (v{{ page.version }})</a>
-<br>
-<a href="triplea:{{ page.mapName | escape | replace: " ", "%20"  }}" style="display: none;" class="button">Open with TripleA (Currently not working)</a>
-<!-- WIP this needs a better design -->
+<a href="triplea:{{ page.mapName | escape | replace: " ", "%20"  }}" class="button">Download with TripleA</a>
+<p style="margin-top: -20px; font-size: 12px;">(Requires pre-release 1.9.0.0.6322 or higher)</p><!-- TODO remove this notice once a new stable release with this feature is out -->
+<a href="{{ page.downloadUrl }}">Manual Download (v{{ page.version }})</a>

--- a/_layouts/maplist.html
+++ b/_layouts/maplist.html
@@ -16,11 +16,16 @@ layout: page
   function search(input){
     const queryArray = input.value.trim().split(" ");
     [].forEach.call(document.getElementsByClassName("maps-col"), function(current){
-      if(queryArray.every(string => current.dataset.mapName.toLowerCase().includes(string.toLowerCase()))){
-        current.style.display = "";
+      if(queryArray.every(string => unescapeHtml(current.dataset.mapName).toLowerCase().includes(string.toLowerCase()))){
+        current.removeAttribute("style");
       } else {
         current.style.display = "none";
       }
     });
+  }
+  function unescapeHtml(input){
+    var element = document.createElement("textarea");
+    element.innerHTML = input;
+    return element.childNodes.length === 0 ? "" : element.childNodes[0].nodeValue;
   }
 </script>

--- a/_layouts/maplist.html
+++ b/_layouts/maplist.html
@@ -6,5 +6,21 @@ layout: page
   | <a href="{{ '/maps-list/featured/' | prepend: site.baseurl }}">Featured Maps</a>
   | <a href="{{ '/maps-list/categories/' | prepend: site.baseurl }}">Categories</a>
   | <a href="{{ '/maps-list/mods/' | prepend: site.baseurl }}">Mods and Skins</a>
+  <input id="mapSearch" type="search" placeholder="Search" oninput="search(this)">
 </p>
-{{ content }}
+<div>
+  {{ content }}
+</div>
+
+<script>
+  function search(input){
+    const queryArray = input.value.trim().split(" ");
+    [].forEach.call(document.getElementsByClassName("maps-col"), function(current){
+      if(queryArray.every(string => current.dataset.mapName.toLowerCase().includes(string.toLowerCase()))){
+        current.style.display = "";
+      } else {
+        current.style.display = "none";
+      }
+    });
+  }
+</script>

--- a/_layouts/maplist.html
+++ b/_layouts/maplist.html
@@ -1,0 +1,10 @@
+---
+layout: page
+---
+<p>
+  <a href="{{ '/maps-list/all/' | prepend: site.baseurl }}">All</a>
+  | <a href="{{ '/maps-list/featured/' | prepend: site.baseurl }}">Featured Maps</a>
+  | <a href="{{ '/maps-list/categories/' | prepend: site.baseurl }}">Categories</a>
+  | <a href="{{ '/maps-list/mods/' | prepend: site.baseurl }}">Mods and Skins</a>
+</p>
+{{ content }}

--- a/_sass/_misc.scss
+++ b/_sass/_misc.scss
@@ -62,6 +62,10 @@
   clear: both;
 }
 
+#mapSearch {
+  float: right;
+}
+
 .section-title {
   padding-top: 0.75em;
 }

--- a/maps.md
+++ b/maps.md
@@ -6,7 +6,7 @@ permalink: /maps/
 
 TripleA is very versatile and can be used for scenarios from Hannibal crossing the Alps to very futuristic and modern time periods. Here are a few examples of the most popular maps on TripleA.
 
-A list of all available Maps can be found [here]({{"/maps-list/" | prepend: site.baseurl }}) or from inside the TripleA client, where you can download them as well.
+A list of all available Maps can be found [here]({{"/maps-list/all/" | prepend: site.baseurl }}) or from inside the TripleA client, where you can download them as well.
 
 ## Big World
 

--- a/maps.md
+++ b/maps.md
@@ -10,37 +10,37 @@ A list of all available Maps can be found [here]({{"/maps-list/" | prepend: site
 
 ## Big World
 
-![Big World Map]({{ "/images/maps/BigWorld.png" | prepend: site.baseurl }})
+[![Big World Map]({{ "/images/maps/BigWorld.png" | prepend: site.baseurl }})]({{ "/map/big-world/" | prepend: site.baseurl }})
 
 A scenario loosely based on the year 1942 of the global conflict of 1939-1945. In Europe, Germany has Leningrad besieged, stands at the gates of Moscow and the verge of defeat at Stalingrad (Dec 1942). In the Pacific, Japan has expanded explosively but faces the turning point at Midway (May 1942).
 
 ## Great War
 
-![Great War Map]({{ "/images/maps/GreatWar.png" | prepend: site.baseurl }})
+[![Great War Map]({{ "/images/maps/GreatWar.png" | prepend: site.baseurl }})]({{ "/map/great-war/" | prepend: site.baseurl }})
 
 The Western Front has bogged down into trench warfare. In the East, titanic armies fight across the vast expanses. While elsewhere, smaller battles are being waged for control of Africa and the Middle East. On the high seas, great armadas clash with one another, seeking dominance over key shipping lanes and the open ocean.
 
 ## 270 BC
 
-![270 BC Map]({{ "/images/maps/270BC.png" | prepend: site.baseurl }})
+[![270 BC Map]({{ "/images/maps/270BC.png" | prepend: site.baseurl }})]({{ "/map/270bc/" | prepend: site.baseurl }})
 
 Make yourself an empire around the Mediterranean Ocean (the known world), in the era when Hellenes, Romans and Phoenicians ruled. Choose from a arsenal of legionnaires, hoplites, onagers, cataphracts, triremes, war elephants and many more.
 
 ## New World Order
 
-![New World Order Map]({{ "/images/maps/NewWorldOrder.png" | prepend: site.baseurl }})
+[![New World Order Map]({{ "/images/maps/NewWorldOrder.png" | prepend: site.baseurl }})]({{ "/map/new-world-order/" | prepend: site.baseurl }})
 
 A September 1939 scenario with a map of Europe, Eastern North America, and Northern Africa. Emulate the opening moves of the Second World War, then crush your enemies in a drawn-out war of attrition.
 
 ## Napoleonic Empires
 
-![Napoleonic Empires Map]({{ "/images/maps/NapoleonicEmpires.png" | prepend: site.baseurl }})
+[![Napoleonic Empires Map]({{ "/images/maps/NapoleonicEmpires.png" | prepend: site.baseurl }})]({{ "/map/napoleonic-empires/" | prepend: site.baseurl }})
 
 The empires of Europe are at war. The upstart French Republic has followed in the footsteps of their American compatriots across the sea and cast off the trappings of monarchy. Can this new light in Europe survive against a host of squabbling adversaries? Or will it fall victim to its own aspirations for empire... Will the Russians be forced to sing *La Marseillaise*? Will the English see the Guillotine raised in Piccadilly? Or will the rule of the monarchs be insured by the restoration of Louis XVIII to the Parisian throne?
 
 ## Middle Earth
 
-![Middle Earth Map]({{ "/images/maps/MiddleEarth.png" | prepend: site.baseurl }})
+[![Middle Earth Map]({{ "/images/maps/MiddleEarth.png" | prepend: site.baseurl }})]({{ "/map/middle-earth/" | prepend: site.baseurl }})
 
 Take part and prevail in Tolkien-based epical conflict  In the south evil armies gather in an attempt to destroy the proud nation of Gondor. Elsewhere, Elves along with their allies attempt to stop expansion of Goblins, Rhun and Saruman.
 

--- a/maps.md
+++ b/maps.md
@@ -4,7 +4,9 @@ title: Maps
 permalink: /maps/
 ---
 
-TripleA is very versatile and can be used for scenarios from Hannibal crossing the Alps to very futuristic and modern time periods. Here are a few examples of the most popular maps on TripleA. (A comprehensive download list can be found inside TripleA using the 'Download Maps' feature.)
+TripleA is very versatile and can be used for scenarios from Hannibal crossing the Alps to very futuristic and modern time periods. Here are a few examples of the most popular maps on TripleA.
+
+A list of all available Maps can be found [here]({{"/maps-list/" | prepend: site.baseurl }}) or from inside the TripleA client, where you can download them as well.
 
 ## Big World
 
@@ -41,10 +43,6 @@ The empires of Europe are at war. The upstart French Republic has followed in th
 ![Middle Earth Map]({{ "/images/maps/MiddleEarth.png" | prepend: site.baseurl }})
 
 Take part and prevail in Tolkien-based epical conflict  In the south evil armies gather in an attempt to destroy the proud nation of Gondor. Elsewhere, Elves along with their allies attempt to stop expansion of Goblins, Rhun and Saruman.
-
-## Game of the Month
-
-TripleA now has a new featured map each month with a special AI challenge. [Click here](https://www.tripleawarclub.org/modules/newbb/viewforum.php?forum=36) to learn more.
 
 ### Past Games of the Month
 * [World War II v5 Second Edition](http://tripleadev.1671093.n2.nabble.com/Game-of-the-month-3-td7589447.html) (September/October 2015)

--- a/maps/all.html
+++ b/maps/all.html
@@ -1,9 +1,8 @@
 ---
-layout: page
+layout: maplist
 title: All Maps
 permalink: /maps-list/all/
 ---
-<p><a href="{{ '/maps-list/featured/' | prepend: site.baseurl }}">Featured Maps</a> |  <a href="{{ '/maps-list/categories/' | prepend: site.baseurl }}">Categories</a> | <a href="{{ '/maps-list/mods/' | prepend: site.baseurl }}">Mods and Skins</a> | <a href="{{ '/maps-list/all/' | prepend: site.baseurl }}">All</a></p>
 <div class="maps-col-wrapper">
   {%- for map in site.maps %}
   {% if map.mapType != "MAP_TOOL" -%}

--- a/maps/all.html
+++ b/maps/all.html
@@ -3,7 +3,7 @@ layout: page
 title: All Maps
 permalink: /maps-list/all/
 ---
-<p><a href="{{ '/maps-list/' | prepend: site.baseurl }}">Featured Maps</a> |  <a href="{{ '/maps-list/categories/' | prepend: site.baseurl }}">Categories</a> | <a href="{{ '/maps-list/mods/' | prepend: site.baseurl }}">Mods and Skins</a> | <a href="{{ '/maps-list/all/' | prepend: site.baseurl }}">All</a></p>
+<p><a href="{{ '/maps-list/featured/' | prepend: site.baseurl }}">Featured Maps</a> |  <a href="{{ '/maps-list/categories/' | prepend: site.baseurl }}">Categories</a> | <a href="{{ '/maps-list/mods/' | prepend: site.baseurl }}">Mods and Skins</a> | <a href="{{ '/maps-list/all/' | prepend: site.baseurl }}">All</a></p>
 <div class="maps-col-wrapper">
   {%- for map in site.maps %}
   {% if map.mapType != "MAP_TOOL" -%}

--- a/maps/all.html
+++ b/maps/all.html
@@ -3,13 +3,13 @@ layout: page
 title: All Maps
 permalink: /maps-list/all/
 ---
-<p><a href="{{ '/maps-list/' | prepend: site.baseurl }}">Maps</a> |  <a href="{{ '/maps-list/categories/' | prepend: site.baseurl }}">Categories</a> | <a href="{{ '/maps-list/mods/' | prepend: site.baseurl }}">Mods and Skins</a> | <a href="{{ '/maps-list/all/' | prepend: site.baseurl }}">All</a></p>
+<p><a href="{{ '/maps-list/' | prepend: site.baseurl }}">Featured Maps</a> |  <a href="{{ '/maps-list/categories/' | prepend: site.baseurl }}">Categories</a> | <a href="{{ '/maps-list/mods/' | prepend: site.baseurl }}">Mods and Skins</a> | <a href="{{ '/maps-list/all/' | prepend: site.baseurl }}">All</a></p>
 <div class="maps-col-wrapper">
   {%- for map in site.maps %}
   {% if map.mapType != "MAP_TOOL" -%}
   <div class="maps-col" data-map-name="{{ map.slug }}">
     <h3>{{ map.mapName }}</h3>
-    <p><a class="maps-col-button button" href="{{ '/map/' | prepend: site.baseurl | append: map.slug }}/">Download</a></p>
+    <p><a class="maps-col-button button" href="{{ '/map/' | prepend: site.baseurl | append: map.slug }}/">View</a></p>
   </div>
   {%- endif -%}
   {%- endfor %}

--- a/maps/all.html
+++ b/maps/all.html
@@ -6,7 +6,7 @@ permalink: /maps-list/all/
 <div class="maps-col-wrapper">
   {%- for map in site.maps %}
   {% if map.mapType != "MAP_TOOL" -%}
-  <div class="maps-col" data-map-name="{{ map.slug }}">
+  <div class="maps-col" data-map-name="{{ map.mapName }}" data-map-name-slug="{{ map.slug }}">
     <h3>{{ map.mapName }}</h3>
     <p><a class="maps-col-button button" href="{{ '/map/' | prepend: site.baseurl | append: map.slug }}/">View</a></p>
   </div>

--- a/maps/all.html
+++ b/maps/all.html
@@ -6,8 +6,8 @@ permalink: /maps-list/all/
 <div class="maps-col-wrapper">
   {%- for map in site.maps %}
   {% if map.mapType != "MAP_TOOL" -%}
-  <div class="maps-col" data-map-name="{{ map.mapName }}" data-map-name-slug="{{ map.slug }}">
-    <h3>{{ map.mapName }}</h3>
+  <div class="maps-col" data-map-name="{{ map.mapName | escape }}" data-map-name-slug="{{ map.slug }}">
+    <h3>{{ map.mapName | escape }}</h3>
     <p><a class="maps-col-button button" href="{{ '/map/' | prepend: site.baseurl | append: map.slug }}/">View</a></p>
   </div>
   {%- endif -%}

--- a/maps/categories.html
+++ b/maps/categories.html
@@ -3,14 +3,14 @@ layout: page
 title: Map Categories
 permalink: /maps-list/categories/
 ---
-<p><a href="{{ '/maps-list/' | prepend: site.baseurl }}">Maps</a> |  <a href="{{ '/maps-list/categories/' | prepend: site.baseurl }}">Categories</a> | <a href="{{ '/maps-list/mods/' | prepend: site.baseurl }}">Mods and Skins</a> | <a href="{{ '/maps-list/all/' | prepend: site.baseurl }}">All</a></p>
+<p><a href="{{ '/maps-list/' | prepend: site.baseurl }}">Featured Maps</a> |  <a href="{{ '/maps-list/categories/' | prepend: site.baseurl }}">Categories</a> | <a href="{{ '/maps-list/mods/' | prepend: site.baseurl }}">Mods and Skins</a> | <a href="{{ '/maps-list/all/' | prepend: site.baseurl }}">All</a></p>
 <div class="maps-col-section high_quality">
   <h2 class="section-title">High Quality Maps</h2>
   {%- for map in site.maps -%}
   {%- if map.mapCategory == "BEST" %}
   <div class="maps-col" data-map-name="{{ map.slug }}">
     <h3>{{ map.mapName }}</h3>
-    <p><a class="maps-col-button button" href="{{ '/map/' | prepend: site.baseurl | append: map.slug }}/">Download</a></p>
+    <p><a class="maps-col-button button" href="{{ '/map/' | prepend: site.baseurl | append: map.slug }}/">View</a></p>
   </div>
   {%- endif -%}
   {%- endfor %}
@@ -21,7 +21,7 @@ permalink: /maps-list/categories/
   {%- if map.mapCategory == "GOOD" %}
   <div class="maps-col" data-map-name="{{ map.slug }}">
     <h3>{{ map.mapName }}</h3>
-    <p><a class="maps-col-button button" href="{{ '/map/' | prepend: site.baseurl | append: map.slug }}/">Download</a></p>
+    <p><a class="maps-col-button button" href="{{ '/map/' | prepend: site.baseurl | append: map.slug }}/">View</a></p>
   </div>
   {%- endif -%}
   {%- endfor %}
@@ -32,7 +32,7 @@ permalink: /maps-list/categories/
   {%- if map.mapCategory == "EXPERIMENTAL" %}
   <div class="maps-col" data-map-name="{{ map.slug }}">
     <h3>{{ map.mapName }}</h3>
-    <p><a class="maps-col-button button" href="{{ '/map/' | prepend: site.baseurl | append: map.slug }}/">Download</a></p>
+    <p><a class="maps-col-button button" href="{{ '/map/' | prepend: site.baseurl | append: map.slug }}/">View</a></p>
   </div>
   {%- endif -%}
   {%- endfor %}

--- a/maps/categories.html
+++ b/maps/categories.html
@@ -7,7 +7,7 @@ permalink: /maps-list/categories/
   <h2 class="section-title">High Quality Maps</h2>
   {%- for map in site.maps -%}
   {%- if map.mapCategory == "BEST" %}
-  <div class="maps-col" data-map-name="{{ map.slug }}">
+  <div class="maps-col" data-map-name="{{ map.mapName }}" data-map-name-slug="{{ map.slug }}">
     <h3>{{ map.mapName }}</h3>
     <p><a class="maps-col-button button" href="{{ '/map/' | prepend: site.baseurl | append: map.slug }}/">View</a></p>
   </div>
@@ -18,7 +18,7 @@ permalink: /maps-list/categories/
   <h2 class="section-title">Quality Maps</h2>
   {%- for map in site.maps -%}
   {%- if map.mapCategory == "GOOD" %}
-  <div class="maps-col" data-map-name="{{ map.slug }}">
+  <div class="maps-col" data-map-name="{{ map.mapName }}" data-map-name-slug="{{ map.slug }}">
     <h3>{{ map.mapName }}</h3>
     <p><a class="maps-col-button button" href="{{ '/map/' | prepend: site.baseurl | append: map.slug }}/">View</a></p>
   </div>
@@ -29,7 +29,7 @@ permalink: /maps-list/categories/
   <h2 class="section-title">Other Maps / Experimental / In Development</h2>
   {%- for map in site.maps -%}
   {%- if map.mapCategory == "EXPERIMENTAL" %}
-  <div class="maps-col" data-map-name="{{ map.slug }}">
+  <div class="maps-col" data-map-name="{{ map.mapName }}" data-map-name-slug="{{ map.slug }}">
     <h3>{{ map.mapName }}</h3>
     <p><a class="maps-col-button button" href="{{ '/map/' | prepend: site.baseurl | append: map.slug }}/">View</a></p>
   </div>

--- a/maps/categories.html
+++ b/maps/categories.html
@@ -7,8 +7,8 @@ permalink: /maps-list/categories/
   <h2 class="section-title">High Quality Maps</h2>
   {%- for map in site.maps -%}
   {%- if map.mapCategory == "BEST" %}
-  <div class="maps-col" data-map-name="{{ map.mapName }}" data-map-name-slug="{{ map.slug }}">
-    <h3>{{ map.mapName }}</h3>
+  <div class="maps-col" data-map-name="{{ map.mapName | escape }}" data-map-name-slug="{{ map.slug }}">
+    <h3>{{ map.mapName | escape }}</h3>
     <p><a class="maps-col-button button" href="{{ '/map/' | prepend: site.baseurl | append: map.slug }}/">View</a></p>
   </div>
   {%- endif -%}
@@ -18,8 +18,8 @@ permalink: /maps-list/categories/
   <h2 class="section-title">Quality Maps</h2>
   {%- for map in site.maps -%}
   {%- if map.mapCategory == "GOOD" %}
-  <div class="maps-col" data-map-name="{{ map.mapName }}" data-map-name-slug="{{ map.slug }}">
-    <h3>{{ map.mapName }}</h3>
+  <div class="maps-col" data-map-name="{{ map.mapName | escape }}" data-map-name-slug="{{ map.slug }}">
+    <h3>{{ map.mapName | escape }}</h3>
     <p><a class="maps-col-button button" href="{{ '/map/' | prepend: site.baseurl | append: map.slug }}/">View</a></p>
   </div>
   {%- endif -%}
@@ -29,8 +29,8 @@ permalink: /maps-list/categories/
   <h2 class="section-title">Other Maps / Experimental / In Development</h2>
   {%- for map in site.maps -%}
   {%- if map.mapCategory == "EXPERIMENTAL" %}
-  <div class="maps-col" data-map-name="{{ map.mapName }}" data-map-name-slug="{{ map.slug }}">
-    <h3>{{ map.mapName }}</h3>
+  <div class="maps-col" data-map-name="{{ map.mapName | escape }}" data-map-name-slug="{{ map.slug }}">
+    <h3>{{ map.mapName | escape }}</h3>
     <p><a class="maps-col-button button" href="{{ '/map/' | prepend: site.baseurl | append: map.slug }}/">View</a></p>
   </div>
   {%- endif -%}

--- a/maps/categories.html
+++ b/maps/categories.html
@@ -3,7 +3,7 @@ layout: page
 title: Map Categories
 permalink: /maps-list/categories/
 ---
-<p><a href="{{ '/maps-list/' | prepend: site.baseurl }}">Featured Maps</a> |  <a href="{{ '/maps-list/categories/' | prepend: site.baseurl }}">Categories</a> | <a href="{{ '/maps-list/mods/' | prepend: site.baseurl }}">Mods and Skins</a> | <a href="{{ '/maps-list/all/' | prepend: site.baseurl }}">All</a></p>
+<p><a href="{{ '/maps-list/featured/' | prepend: site.baseurl }}">Featured Maps</a> |  <a href="{{ '/maps-list/categories/' | prepend: site.baseurl }}">Categories</a> | <a href="{{ '/maps-list/mods/' | prepend: site.baseurl }}">Mods and Skins</a> | <a href="{{ '/maps-list/all/' | prepend: site.baseurl }}">All</a></p>
 <div class="maps-col-section high_quality">
   <h2 class="section-title">High Quality Maps</h2>
   {%- for map in site.maps -%}

--- a/maps/categories.html
+++ b/maps/categories.html
@@ -1,9 +1,8 @@
 ---
-layout: page
+layout: maplist
 title: Map Categories
 permalink: /maps-list/categories/
 ---
-<p><a href="{{ '/maps-list/featured/' | prepend: site.baseurl }}">Featured Maps</a> |  <a href="{{ '/maps-list/categories/' | prepend: site.baseurl }}">Categories</a> | <a href="{{ '/maps-list/mods/' | prepend: site.baseurl }}">Mods and Skins</a> | <a href="{{ '/maps-list/all/' | prepend: site.baseurl }}">All</a></p>
 <div class="maps-col-section high_quality">
   <h2 class="section-title">High Quality Maps</h2>
   {%- for map in site.maps -%}

--- a/maps/featured.html
+++ b/maps/featured.html
@@ -6,7 +6,7 @@ permalink: /maps-list/featured/
 <div class="maps-col-wrapper">
   {%- for map in site.maps -%}
   {%- if map.mapCategory == "BEST" %}
-  <div class="maps-col" data-map-name="{{ map.mapName }}" data-map-name-slug="{{ map.slug }}">
+  <div class="maps-col" data-map-name="{{ map.mapName | escape }}" data-map-name-slug="{{ map.slug }}">
     <h3>{{ map.mapName }}</h3>
     <p><a class="maps-col-button button" href="{{ '/map/' | prepend: site.baseurl | append: map.slug }}/">View</a></p>
   </div>

--- a/maps/featured.html
+++ b/maps/featured.html
@@ -6,7 +6,7 @@ permalink: /maps-list/featured/
 <div class="maps-col-wrapper">
   {%- for map in site.maps -%}
   {%- if map.mapCategory == "BEST" %}
-  <div class="maps-col" data-map-name="{{ map.slug }}">
+  <div class="maps-col" data-map-name="{{ map.mapName }}" data-map-name-slug="{{ map.slug }}">
     <h3>{{ map.mapName }}</h3>
     <p><a class="maps-col-button button" href="{{ '/map/' | prepend: site.baseurl | append: map.slug }}/">View</a></p>
   </div>

--- a/maps/featured.html
+++ b/maps/featured.html
@@ -7,7 +7,7 @@ permalink: /maps-list/featured/
   {%- for map in site.maps -%}
   {%- if map.mapCategory == "BEST" %}
   <div class="maps-col" data-map-name="{{ map.mapName | escape }}" data-map-name-slug="{{ map.slug }}">
-    <h3>{{ map.mapName }}</h3>
+    <h3>{{ map.mapName | escape }}</h3>
     <p><a class="maps-col-button button" href="{{ '/map/' | prepend: site.baseurl | append: map.slug }}/">View</a></p>
   </div>
   {%- endif -%}

--- a/maps/featured.html
+++ b/maps/featured.html
@@ -1,9 +1,8 @@
 ---
-layout: page
+layout: maplist
 title: Featured Maps
 permalink: /maps-list/featured/
 ---
-<p><a href="{{ '/maps-list/featured/' | prepend: site.baseurl }}">Featured Maps</a> |  <a href="{{ '/maps-list/categories/' | prepend: site.baseurl }}">Categories</a> | <a href="{{ '/maps-list/mods/' | prepend: site.baseurl }}">Mods and Skins</a> | <a href="{{ '/maps-list/all/' | prepend: site.baseurl }}">All</a></p>
 <div class="maps-col-wrapper">
   {%- for map in site.maps -%}
   {%- if map.mapCategory == "BEST" %}

--- a/maps/featured.html
+++ b/maps/featured.html
@@ -1,9 +1,9 @@
 ---
 layout: page
 title: Featured Maps
-permalink: /maps-list/
+permalink: /maps-list/featured/
 ---
-<p><a href="{{ '/maps-list/' | prepend: site.baseurl }}">Featured Maps</a> |  <a href="{{ '/maps-list/categories/' | prepend: site.baseurl }}">Categories</a> | <a href="{{ '/maps-list/mods/' | prepend: site.baseurl }}">Mods and Skins</a> | <a href="{{ '/maps-list/all/' | prepend: site.baseurl }}">All</a></p>
+<p><a href="{{ '/maps-list/featured/' | prepend: site.baseurl }}">Featured Maps</a> |  <a href="{{ '/maps-list/categories/' | prepend: site.baseurl }}">Categories</a> | <a href="{{ '/maps-list/mods/' | prepend: site.baseurl }}">Mods and Skins</a> | <a href="{{ '/maps-list/all/' | prepend: site.baseurl }}">All</a></p>
 <div class="maps-col-wrapper">
   {%- for map in site.maps -%}
   {%- if map.mapCategory == "BEST" %}

--- a/maps/index.html
+++ b/maps/index.html
@@ -1,16 +1,15 @@
 ---
 layout: page
-title: Maps
+title: Featured Maps
 permalink: /maps-list/
 ---
-<p><a href="{{ '/maps-list/' | prepend: site.baseurl }}">Maps</a> |  <a href="{{ '/maps-list/categories/' | prepend: site.baseurl }}">Categories</a> | <a href="{{ '/maps-list/mods/' | prepend: site.baseurl }}">Mods and Skins</a> | <a href="{{ '/maps-list/all/' | prepend: site.baseurl }}">All</a></p>
+<p><a href="{{ '/maps-list/' | prepend: site.baseurl }}">Featured Maps</a> |  <a href="{{ '/maps-list/categories/' | prepend: site.baseurl }}">Categories</a> | <a href="{{ '/maps-list/mods/' | prepend: site.baseurl }}">Mods and Skins</a> | <a href="{{ '/maps-list/all/' | prepend: site.baseurl }}">All</a></p>
 <div class="maps-col-wrapper">
-  <h2 class="section-title">Featured Maps</h2>
   {%- for map in site.maps -%}
   {%- if map.mapCategory == "BEST" %}
   <div class="maps-col" data-map-name="{{ map.slug }}">
     <h3>{{ map.mapName }}</h3>
-    <p><a class="maps-col-button button" href="{{ '/map/' | prepend: site.baseurl | append: map.slug }}/">Download</a></p>
+    <p><a class="maps-col-button button" href="{{ '/map/' | prepend: site.baseurl | append: map.slug }}/">View</a></p>
   </div>
   {%- endif -%}
   {%- endfor %}

--- a/maps/mods.html
+++ b/maps/mods.html
@@ -7,7 +7,7 @@ permalink: /maps-list/mods/
   <h2 class="section-title">Map Mods</h2>
   {%- for map in site.maps -%}
   {%- if map.mapType == "MAP_MOD" %}
-  <div class="maps-col" data-map-name="{{ map.slug }}">
+  <div class="maps-col" data-map-name="{{ map.mapName }}" data-map-name-slug="{{ map.slug }}">
     <h3>{{ map.mapName }}</h3>
     <p><a class="maps-col-button button" href="{{ '/map/' | prepend: site.baseurl | append: map.slug }}/">View</a></p>
   </div>
@@ -18,7 +18,7 @@ permalink: /maps-list/mods/
   <h2 class="section-title">Map Skins</h2>
   {%- for map in site.maps -%}
   {%- if map.mapType == "MAP_SKIN" %}
-    <div class="maps-col" data-map-name="{{ map.slug }}">
+    <div class="maps-col" data-map-name="{{ map.mapName }}" data-map-name-slug="{{ map.slug }}">
       <h3>{{ map.mapName }}</h3>
       <p><a class="maps-col-button button" href="{{ '/map/' | prepend: site.baseurl | append: map.slug }}/">View</a></p>
     </div>

--- a/maps/mods.html
+++ b/maps/mods.html
@@ -7,8 +7,8 @@ permalink: /maps-list/mods/
   <h2 class="section-title">Map Mods</h2>
   {%- for map in site.maps -%}
   {%- if map.mapType == "MAP_MOD" %}
-  <div class="maps-col" data-map-name="{{ map.mapName }}" data-map-name-slug="{{ map.slug }}">
-    <h3>{{ map.mapName }}</h3>
+  <div class="maps-col" data-map-name="{{ map.mapName | escape }}" data-map-name-slug="{{ map.slug }}">
+    <h3>{{ map.mapName | escape }}</h3>
     <p><a class="maps-col-button button" href="{{ '/map/' | prepend: site.baseurl | append: map.slug }}/">View</a></p>
   </div>
   {%- endif -%}
@@ -18,8 +18,8 @@ permalink: /maps-list/mods/
   <h2 class="section-title">Map Skins</h2>
   {%- for map in site.maps -%}
   {%- if map.mapType == "MAP_SKIN" %}
-    <div class="maps-col" data-map-name="{{ map.mapName }}" data-map-name-slug="{{ map.slug }}">
-      <h3>{{ map.mapName }}</h3>
+    <div class="maps-col" data-map-name="{{ map.mapName | escape }}" data-map-name-slug="{{ map.slug }}">
+      <h3>{{ map.mapName | escape }}</h3>
       <p><a class="maps-col-button button" href="{{ '/map/' | prepend: site.baseurl | append: map.slug }}/">View</a></p>
     </div>
   {%- endif -%}

--- a/maps/mods.html
+++ b/maps/mods.html
@@ -3,14 +3,14 @@ layout: page
 title: Mods and Skins
 permalink: /maps-list/mods/
 ---
-<p><a href="{{ '/maps-list/' | prepend: site.baseurl }}">Maps</a> |  <a href="{{ '/maps-list/categories/' | prepend: site.baseurl }}">Categories</a> | <a href="{{ '/maps-list/mods/' | prepend: site.baseurl }}">Mods and Skins</a> | <a href="{{ '/maps-list/all/' | prepend: site.baseurl }}">All</a></p>
+<p><a href="{{ '/maps-list/' | prepend: site.baseurl }}">Featured Maps</a> |  <a href="{{ '/maps-list/categories/' | prepend: site.baseurl }}">Categories</a> | <a href="{{ '/maps-list/mods/' | prepend: site.baseurl }}">Mods and Skins</a> | <a href="{{ '/maps-list/all/' | prepend: site.baseurl }}">All</a></p>
 <div class="maps-col-section mod">
   <h2 class="section-title">Map Mods</h2>
   {%- for map in site.maps -%}
   {%- if map.mapType == "MAP_MOD" %}
   <div class="maps-col" data-map-name="{{ map.slug }}">
     <h3>{{ map.mapName }}</h3>
-    <p><a class="maps-col-button button" href="{{ '/map/' | prepend: site.baseurl | append: map.slug }}/">Download</a></p>
+    <p><a class="maps-col-button button" href="{{ '/map/' | prepend: site.baseurl | append: map.slug }}/">View</a></p>
   </div>
   {%- endif -%}
   {%- endfor %}
@@ -21,7 +21,7 @@ permalink: /maps-list/mods/
   {%- if map.mapType == "MAP_SKIN" %}
     <div class="maps-col" data-map-name="{{ map.slug }}">
       <h3>{{ map.mapName }}</h3>
-      <p><a class="maps-col-button button" href="{{ '/map/' | prepend: site.baseurl | append: map.slug }}/">Download</a></p>
+      <p><a class="maps-col-button button" href="{{ '/map/' | prepend: site.baseurl | append: map.slug }}/">View</a></p>
     </div>
   {%- endif -%}
   {%- endfor %}

--- a/maps/mods.html
+++ b/maps/mods.html
@@ -1,9 +1,8 @@
 ---
-layout: page
+layout: maplist
 title: Mods and Skins
 permalink: /maps-list/mods/
 ---
-<p><a href="{{ '/maps-list/featured/' | prepend: site.baseurl }}">Featured Maps</a> |  <a href="{{ '/maps-list/categories/' | prepend: site.baseurl }}">Categories</a> | <a href="{{ '/maps-list/mods/' | prepend: site.baseurl }}">Mods and Skins</a> | <a href="{{ '/maps-list/all/' | prepend: site.baseurl }}">All</a></p>
 <div class="maps-col-section mod">
   <h2 class="section-title">Map Mods</h2>
   {%- for map in site.maps -%}

--- a/maps/mods.html
+++ b/maps/mods.html
@@ -3,7 +3,7 @@ layout: page
 title: Mods and Skins
 permalink: /maps-list/mods/
 ---
-<p><a href="{{ '/maps-list/' | prepend: site.baseurl }}">Featured Maps</a> |  <a href="{{ '/maps-list/categories/' | prepend: site.baseurl }}">Categories</a> | <a href="{{ '/maps-list/mods/' | prepend: site.baseurl }}">Mods and Skins</a> | <a href="{{ '/maps-list/all/' | prepend: site.baseurl }}">All</a></p>
+<p><a href="{{ '/maps-list/featured/' | prepend: site.baseurl }}">Featured Maps</a> |  <a href="{{ '/maps-list/categories/' | prepend: site.baseurl }}">Categories</a> | <a href="{{ '/maps-list/mods/' | prepend: site.baseurl }}">Mods and Skins</a> | <a href="{{ '/maps-list/all/' | prepend: site.baseurl }}">All</a></p>
 <div class="maps-col-section mod">
   <h2 class="section-title">Map Mods</h2>
   {%- for map in site.maps -%}


### PR DESCRIPTION
This PR allows user to download maps directly from the website if they have the latest prerelease of TripleA installed (1.9.0.0.6322+)
How it looks now (example):
![screenshot-2017-8-26 270bc triplea map](https://user-images.githubusercontent.com/8350879/29745236-c1df7b46-8ab5-11e7-8fd6-3b6bba2a3fe7.png)
