### PR TITLE
Add partial release notes for build 7062

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -12,6 +12,11 @@ permalink: /release_notes/
 * Improve security of network game authentication (#2107).
 * Add option to securely save PBEM/PBF credentials (#1955).
 * Fix out-of-date map check (#1695).
+* Fight a single battle automatically
+* Upgrade retreat options - no double prompt with one valid territory
+    - don't offer prompt when only defenseless units remain
+- Show dice details by default in PBF/PBEM
+- Auto fight battles with no defenders who can fire and no dependent battles
 
 ## 1.9.0.0.5855 - July 22nd 2017
 
@@ -38,8 +43,6 @@ permalink: /release_notes/
 
 * Primarily bug fixes. SBR rules now working again on most maps (map XMLs updated, download of latest maps required)
 
-
-## Changes for 1.9.0.0
 
 * Minimum Java version is now Java 1.8
 * New Install4j Installers available for all OS, replaces makensis installers

--- a/release_notes.md
+++ b/release_notes.md
@@ -14,9 +14,24 @@ permalink: /release_notes/
 * Fix out-of-date map check (#1695).
 * Fight a single battle automatically
 * Upgrade retreat options - no double prompt with one valid territory
-    - don't offer prompt when only defenseless units remain
-- Show dice details by default in PBF/PBEM
-- Auto fight battles with no defenders who can fire and no dependent battles
+  * don't offer prompt when only defenseless units remain
+* Show dice details by default in PBF/PBEM
+* Auto fight battles with no defenders who can fire and no dependent battles
+* Add experimental savegame format (#2128)
+* Setting Menu Overhaul (#2137)
+* Bugfix: Maps can have AI-only players(#2149)
+* Removal of the Beta Map Creator (#2156)
+* Enabled TripleA to download Maps via a browser (#2274)
+* Updated many outdated links
+* Improved internal password security (#2101)
+* General smaller performance improvements
+* Several smaller usability improvements
+* Using Java 1.8.0_144 for the installer now (#2384)
+* Removed the 'old jar' functionality (#2284)
+
+And many more internal changes, bugfixes etc.
+See the full List [here](https://github.com/triplea-game/triplea/pulls?utf8=%E2%9C%93&q=merged%3A%3E2017-07-22)
+
 
 ## 1.9.0.0.5855 - July 22nd 2017
 
@@ -27,6 +42,7 @@ permalink: /release_notes/
 * Improved naming of auto save games.
 * Set all buttons to select alliances more easily
 * Bug Fix: Fix game crash when game release version is updated
+* Associate TripleA savegames with TripleA
 
 ## 1.9.0.0.3627
 

--- a/release_notes.md
+++ b/release_notes.md
@@ -4,6 +4,15 @@ title: Release Notes
 permalink: /release_notes/
 ---
 
+## 1.9.0.0.7062 - October 14th 2017
+
+* Add option to securely save lobby credentials (#2395).
+* Fix console opening when playing a network game (#2289).
+* Fix threading errors reported when starting Map Creator (#2238).
+* Improve security of network game authentication (#2107).
+* Add option to securely save PBEM/PBF credentials (#1955).
+* Fix out-of-date map check (#1695).
+
 ## 1.9.0.0.5855 - July 22nd 2017
 
 * Compatibility fixes for moderator actions.


### PR DESCRIPTION
Addressing @DanVanAtta's [comment](https://github.com/triplea-game/triplea/issues/1768#issuecomment-336670272) that we need to work on the release notes for 7062.

I added the PRs I authored that I felt would have significance to an end-user.  Some of those have questionable value, so please feel free to suggest their removal.  Note also that some of those probably made it into the 5802 and 5855 releases, but since those are no longer considered official releases, I just lumped them all under 7062.

@DanVanAtta @RoiEXLab @ron-murhammer @simon33-2 Not sure if everybody wants to just push commits to this branch with their contributions, or if we should  do it in separate PRs.