### PR TITLE
Group 7062 notes, and a few edits

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -18,21 +18,19 @@ permalink: /release_notes/
 * Show dice details by default in PBF/PBEM
 * Auto fight battles with no defenders who can fire and no dependent battles
 * Setting Menu Overhaul (#2137)
-* Removal of the Beta Map Creator (#2156)
 * Enabled TripleA to download Maps via a browser (#2274)
-* Updated many outdated links
 * Improved internal password security (#2101)
-* General smaller performance improvements
-* Several smaller usability improvements
-* Using Java 1.8.0_144 for the installer now (#2384)
-* Removed the 'old jar' functionality (#2284)
 
 ### Fixed
-* Fix console opening when playing a network game (#2289).
-* Fix threading errors reported when starting Map Creator (#2238).
-* Fix out-of-date map check (#1695).
-* Fix: Maps can have AI-only players(#2149)
+* console opening when playing a network game (#2289).
+* threading errors reported when starting Map Creator (#2238).
+* out-of-date map check (#1695).
+* Maps can have AI-only players(#2149)
+* Updated many outdated game links
 
+### Removed
+* Removal of the Beta Map Creator (#2156)
+* Removed the 'old jar' functionality (#2284)
 
 And many more internal changes, bugfixes etc,
 See the [full List here](https://github.com/triplea-game/triplea/pulls?utf8=%E2%9C%93&q=merged%3A%3E2017-07-22)

--- a/release_notes.md
+++ b/release_notes.md
@@ -6,20 +6,18 @@ permalink: /release_notes/
 
 ## 1.9.0.0.7062 - October 14th 2017
 
-* Add option to securely save lobby credentials (#2395).
-* Fix console opening when playing a network game (#2289).
-* Fix threading errors reported when starting Map Creator (#2238).
-* Improve security of network game authentication (#2107).
+### Added
+* Add 'remember me' option when logging in to lobby, credentials are to securely saved on your computer (#2395).
 * Add option to securely save PBEM/PBF credentials (#1955).
-* Fix out-of-date map check (#1695).
-* Fight a single battle automatically
+
+### Changed
 * Upgrade retreat options - no double prompt with one valid territory
   * don't offer prompt when only defenseless units remain
+* Improve security of network game authentication (#2107).
+* Fight a single battle automatically
 * Show dice details by default in PBF/PBEM
 * Auto fight battles with no defenders who can fire and no dependent battles
-* Add experimental savegame format (#2128)
 * Setting Menu Overhaul (#2137)
-* Bugfix: Maps can have AI-only players(#2149)
 * Removal of the Beta Map Creator (#2156)
 * Enabled TripleA to download Maps via a browser (#2274)
 * Updated many outdated links
@@ -29,8 +27,15 @@ permalink: /release_notes/
 * Using Java 1.8.0_144 for the installer now (#2384)
 * Removed the 'old jar' functionality (#2284)
 
-And many more internal changes, bugfixes etc.
-See the full List [here](https://github.com/triplea-game/triplea/pulls?utf8=%E2%9C%93&q=merged%3A%3E2017-07-22)
+### Fixed
+* Fix console opening when playing a network game (#2289).
+* Fix threading errors reported when starting Map Creator (#2238).
+* Fix out-of-date map check (#1695).
+* Fix: Maps can have AI-only players(#2149)
+
+
+And many more internal changes, bugfixes etc,
+See the [full List here](https://github.com/triplea-game/triplea/pulls?utf8=%E2%9C%93&q=merged%3A%3E2017-07-22)
 
 
 ## 1.9.0.0.5855 - July 22nd 2017


### PR DESCRIPTION
Inspired by @ssoloff's suggestion to use: http://keepachangelog.com/en/1.0.0/, incorporated 'added' 'changed' and 'fixed' sections. Secondly, the wording on the lobby credential storage was updated to note we have a 'remember feature', which is hopefully more descriptive to game players.