### PR TITLE
Use consistent grammar and punctuation in release notes

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -7,37 +7,37 @@ permalink: /release_notes/
 ## 1.9.0.0.7062 - October 14th 2017
 
 ### Added
-* Add 'remember me' option when logging in to lobby, credentials are to securely saved on your computer (#2395).
-* Add option to securely save PBEM/PBF credentials (#1955).
+* Add 'remember me' option when logging in to lobby, credentials are securely saved on your computer (#2395)
+* Add option to securely save PBEM/PBF credentials (#1955)
 * Set all buttons to select alliances more easily in single player mode
 
 ### Changed
 * Upgrade retreat options - no double prompt with one valid territory
-  * don't offer prompt when only defenseless units remain
+  * Don't offer prompt when only defenseless units remain
 * Game play speedup, automatically select a single battle for combat
-* Game play speedup, automatically select defenseless unit battles first. For example, when selecting battles to fight, all battles against undefended transports would be auto-selected first.
-* Setting Window available from the file menu was overhauled (#2137)
+* Game play speedup, automatically select defenseless unit battles first (e.g. when selecting battles to fight, all battles against undefended transports would be auto-selected first)
+* Overhaul Settings Window available from the file menu (#2137)
 * Show dice details is now a default option in PBF/PBEM
-* Enabled TripleA to download Maps via a browser (#2274)
-* Associate TripleA savegames with TripleA at the OS level when running the installer.
-* Improved naming of auto save games.
-* Improved internal password security (#2101)
-* Improve security of network game authentication (#2107).
+* Enable TripleA to download Maps via a browser (#2274)
+* Associate TripleA savegames with TripleA at the OS level when running the installer
+* Improve naming of auto save games
+* Improve internal password security (#2101)
+* Improve security of network game authentication (#2107)
 
 ### Fixed
-* console opening when playing a network game (#2289).
-* threading errors reported when starting Map Creator (#2238).
-* out-of-date map check (#1695).
-* Maps can have AI-only players(#2149)
-* Updated many outdated game links
+* Console opening when playing a network game (#2289)
+* Threading errors reported when starting Map Creator (#2238)
+* Out-of-date map check (#1695)
+* Maps can have AI-only players (#2149)
+* Update many outdated game links
 * Fix game crash when game release version is updated
 
 ### Removed
 * Removal of the Beta Map Creator (#2156)
 * Removed the 'old jar' functionality (#2284)
 
-And many more internal changes, bugfixes etc,
-See the [full List here](https://github.com/triplea-game/triplea/pulls?utf8=%E2%9C%93&q=merged%3A%3E2017-07-22)
+And many more internal changes, bugfixes, etc.
+See the [full list here](https://github.com/triplea-game/triplea/pulls?utf8=%E2%9C%93&q=merged%3A%3E2017-07-22).
 
 
 ## 1.9.0.0.3635

--- a/release_notes.md
+++ b/release_notes.md
@@ -4,7 +4,7 @@ title: Release Notes
 permalink: /release_notes/
 ---
 
-## 1.9.0.0.7062 - October 14th 2017
+## 1.9.0.0.7062 - October 11th 2017
 
 ### Added
 * Add 'remember me' option when logging in to lobby, credentials are securely saved on your computer (#2395)
@@ -37,10 +37,9 @@ permalink: /release_notes/
 * Removed the 'old jar' functionality (#2284)
 
 And many more internal changes, bugfixes, etc.
-See the [full list here](https://github.com/triplea-game/triplea/pulls?utf8=%E2%9C%93&q=merged%3A%3E2017-07-22).
+See the [full list here](https://github.com/triplea-game/triplea/pulls?q=merged%3A2017-01-21T12%3A42%3A00-05%3A00..2017-10-11T12%3A16%3A00-04%3A00).
 
-
-## 1.9.0.0.3635
+## 1.9.0.0.3635 - January 21st 2017
 
 * Game no longer shuts down when host disconnects, allows game to be saved.
 * All rocket targets are now selected before dice are rolled.


### PR DESCRIPTION
Some cosmetic changes so it doesn't read like four different people wrote the release notes: :smile:

* Capitalize first word on each line.
* Remove trailing periods.
* Use active voice.

I also corrected the date of the 7062 release (somehow I flubbed it by three days when I submitted the original PR).  I added an upper bound to the PR search URL so it doesn't return PRs merged after 7062 was released and moved the lower bound to the 3635 release date.