### PR TITLE
Rollback release number in release notes

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -4,7 +4,7 @@ title: Release Notes
 permalink: /release_notes/
 ---
 
-## 1.9.0.0.7062 - October 11th 2017
+## Next Compatible Release
 
 ### Added
 * 'Remember me' option when logging in to lobby, credentials are securely saved on your computer (#2395)


### PR DESCRIPTION
Download map windows is unusable: https://github.com/triplea-game/triplea/issues/2511, given that bug we rolled back to 3635 as the latest release.