### PR TITLE
Update release notes

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -8,7 +8,7 @@ permalink: /release_notes/
 
 See the [full list here](https://github.com/triplea-game/triplea/pulls?q=merged%3A%3E%3D2017-10-28T19%3A46%3A00-04%3A00).
 
-## 1.9.0.0.7342 - October 28th 2017
+## 1.9.0.0.7342 - November 1st 2017
 
 ### Added
 * Wait indicator during lobby login (#2548)

--- a/release_notes.md
+++ b/release_notes.md
@@ -4,6 +4,10 @@ title: Release Notes
 permalink: /release_notes/
 ---
 
+## Unreleased
+
+See the [full list here](https://github.com/triplea-game/triplea/pulls?q=merged%3A%3E%3D2017-10-28T19%3A46%3A00-04%3A00).
+
 ## 1.9.0.0.7342 - October 28th 2017
 
 ### Added

--- a/release_notes.md
+++ b/release_notes.md
@@ -4,8 +4,19 @@ title: Release Notes
 permalink: /release_notes/
 ---
 
-## 1.9.0.0.7218 - Nov 1st 2017
+## 1.9.0.0.7342 - October 28th 2017
 
+### Added
+* Wait indicator during lobby login (#2548)
+
+### Changed
+* Reduced default simulation run counts (#2531)
+
+### Fixed
+* Slow battle calculator (#2544)
+* Map blend rendering when zoom < 100%
+
+See the [full list here](https://github.com/triplea-game/triplea/pulls?q=merged%3A2017-10-11T12%3A16%3A00-04%3A00..2017-10-28T19%3A46%3A00-04%3A00).
 
 ## 1.9.0.0.7062 - October 11th 2017
 


### PR DESCRIPTION
I did this to help me figure out which areas needed to be tested for the proposed 1.9.0.0.7378 release.

Some things to note:

* 1.9.0.0.7218 was released on 2017-10-22, not 2017-11-01.  I'm not even sure if this version was ever released (I don't remember seeing an announcement in Gitter or anything).  @DanVanAtta, let me know if this actually was an official release before 1.9.0.0.7342 was promoted, and I'll add it back with appropriate changes.
* Added a section for 1.9.0.0.7342 and included my PRs.  As before, please submit follow-up PRs to flesh out the complete list of notable PRs.
* Added a section for unreleased changes.  Mostly I did this so that the PR link is available for anyone to view unreleased PRs, but it can also serve as a placeholder for devs to add notable PRs as they are merged so we don't have to do update the release notes all at once after the release is promoted.