### PR TITLE
Upgrade A&A.org link to HTTPS

### DIFF
--- a/community.html
+++ b/community.html
@@ -20,7 +20,7 @@ permalink: /community/
   <p>Community website with ladder, tournaments, and forums for finding matches and discussing game strategy.</p>
 </div>
 <div class="community-col">
-  <h2><a href="http://www.axisandallies.org/">AxisAndAllies.org</a></h2>
+  <h2><a href="https://www.axisandallies.org/">AxisAndAllies.org</a></h2>
   <img src="../images/AAorg.png" alt="Axis &amp; Allies Icon">
-  <p><a href="http://www.axisandallies.org/">AxisAndAllies.org</a> is a great resource for TripleA and Axis and Allies players. It has vast forums, alternate rules, and website.</p>
+  <p><a href="https://www.axisandallies.org/">AxisAndAllies.org</a> is a great resource for TripleA and Axis and Allies players. It has vast forums, alternate rules, and website.</p>
 </div>


### PR DESCRIPTION
Fixes a build warning now that A&A.org HTTP is being redirected to HTTPS.