### PR TITLE
Cache binary testing requirements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,8 @@
 language: generic
+cache:
+  directories:
+    - /home/travis/.rvm/
+    - ./.binary/
 before_install:
   - rvm reinstall ruby-head --binary
   - jdk_switcher use oraclejdk8

--- a/.travis/install_from_source
+++ b/.travis/install_from_source
@@ -1,5 +1,11 @@
 #!/bin/bash
 set -e
+
+if [ -d "./.binary/" ]; then
+  echo "Skipping Build, .binary folder already exists."
+  exit
+fi
+
 mkdir ./.binary/
 cd ./.binary/
 


### PR DESCRIPTION
Fixes #280
The install_from_source script may need some enhancements, because we currently need to clear the cache manually when we want to update a tool we're building