### PR TITLE
Combine help and forums header link. 

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -6,8 +6,7 @@
       <li class="menu-items"><a href="{{ '/download/' | prepend: site.baseurl }}">Download</a></li>
 
       <li class="menu-items"><a href="{{ '/maps/' | prepend: site.baseurl }}">Maps</a></li>
-      <li class="menu-items"><a href="https://forums.triplea-game.org/category/10/help-questions">Help</a></li>
-      <li class="menu-items"><a href="https://forums.triplea-game.org">Forums</a></li>
+      <li class="menu-items"><a href="https://forums.triplea-game.org">Help &amp; Forums</a></li>
     </ul>
   </nav>
 </header>


### PR DESCRIPTION
They both link to the same page, it's a bit odd. Combining helps make it clear they go to the same website, from there it should be straight forward to scan and find the word help

Before:
![before](https://user-images.githubusercontent.com/12397753/36068698-58dbe3a0-0e90-11e8-8987-b526e2ed9876.png)


After:
![after](https://user-images.githubusercontent.com/12397753/36068699-5ce04c84-0e90-11e8-9eb0-e81e51100293.png)

