### PR TITLE
Delete googlefbbe135e73b5eaf1.html

### DIFF
--- a/googlefbbe135e73b5eaf1.html
+++ b/googlefbbe135e73b5eaf1.html
@@ -1,1 +1,0 @@
-google-site-verification: googlefbbe135e73b5eaf1.html


### PR DESCRIPTION
So I was tinkering around with DNS records a bit, to have the domains migrated to a newer google search console model.
I discovered the reason why DNS ownership validation didn't work and fixed it (I learned that CNAME is evil and namecheap doesn't offer a workaround like many other providers). So this file is no longer necessary. Not sure about the other validation file:
@DanVanAtta Is the file still necessary? If you haven't actually looked at the search console for a while, I'd offer you to remove the other file and add you as other admin to the domain property.