### PR TITLE
Resolve syntax errors

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -1,15 +1,15 @@
 <!DOCTYPE html>
 <html lang="en">
-  {% include head.html -%}
+  {% include head.html %}
   <body>
     <div id="container">
-      {% include header.html -%}
+      {% include header.html %}
       <div id="body">
         <div id="page-content">
           {{ content }}
         </div>
       </div>
-      {% include footer.html -%}
+      {% include footer.html %}
     </div>
   </body>
 </html>

--- a/maps/categories.html
+++ b/maps/categories.html
@@ -6,40 +6,40 @@ permalink: /maps-list/maps/categories/
 <span class="flex-container row-reverse"><span class="flex-right-align-item">Sort by: <a href="{{ '/maps-list/maps/' | prepend: site.baseurl }}">Alphabet</a></span></span>
 <h2 class="section-title mobile-smaller-text">High Quality Maps</h2>
 <div class="maps-col-wrapper">
-  {%- for map in site.maps -%}
-  {%- if map.mapCategory == "BEST" %}
+  {% for map in site.maps %}
+  {% if map.mapCategory == "BEST" %}
   <div class="maps-col" data-map-name="{{ map.mapName | escape }}" data-map-name-slug="{{ map.slug }}">
     <div class="maps-col-content-wrapper">
       <h3 class="maps-col-item">{{ map.mapName | escape }}</h3>
       <p class="maps-col-item"><a class="maps-col-button button" href="{{ '/map/' | prepend: site.baseurl | append: map.slug }}/">View</a></p>
     </div>
   </div>
-  {%- endif -%}
-  {%- endfor %}
+  {% endif %}
+  {% endfor %}
 </div>
 <h2 class="section-title mobile-smaller-text">Quality Maps</h2>
 <div class="maps-col-wrapper">
-  {%- for map in site.maps -%}
-  {%- if map.mapCategory == "GOOD" %}
+  {% for map in site.maps %}
+  {% if map.mapCategory == "GOOD" %}
   <div class="maps-col" data-map-name="{{ map.mapName | escape }}" data-map-name-slug="{{ map.slug }}">
     <div class="maps-col-content-wrapper">
       <h3 class="maps-col-item">{{ map.mapName | escape }}</h3>
       <p class="maps-col-item"><a class="maps-col-button button" href="{{ '/map/' | prepend: site.baseurl | append: map.slug }}/">View</a></p>
     </div>
   </div>
-  {%- endif -%}
-  {%- endfor %}
+  {% endif %}
+  {% endfor %}
 </div>
 <h2 class="section-title mobile-smaller-text">Other&nbsp;Maps / Experimental / In&nbsp;Development</h2>
 <div class="maps-col-wrapper">
-  {%- for map in site.maps -%}
-  {%- if map.mapCategory == "EXPERIMENTAL" %}
+  {% for map in site.maps %}
+  {% if map.mapCategory == "EXPERIMENTAL" %}
   <div class="maps-col" data-map-name="{{ map.mapName | escape }}" data-map-name-slug="{{ map.slug }}">
     <div class="maps-col-content-wrapper">
       <h3 class="maps-col-item">{{ map.mapName | escape }}</h3>
       <p class="maps-col-item"><a class="maps-col-button button" href="{{ '/map/' | prepend: site.baseurl | append: map.slug }}/">View</a></p>
     </div>
   </div>
-  {%- endif -%}
-  {%- endfor %}
+  {% endif %}
+  {% endfor %}
 </div>

--- a/maps/maps.html
+++ b/maps/maps.html
@@ -6,14 +6,14 @@ permalink: /maps-list/maps/
 {% assign testvar = "test" %}
 <span class="flex-container row-reverse"><span class="flex-right-align-item">Sort by: <a href="{{ '/maps-list/maps/categories/' | prepend: site.baseurl }}">Category</a></span></span>
 <div class="maps-col-wrapper">
-  {%- for map in site.maps %}
-  {% if map.mapCategory -%}
+  {% for map in site.maps %}
+  {% if map.mapCategory %}
   <div class="maps-col" data-map-name="{{ map.mapName | escape }}" data-map-name-slug="{{ map.slug }}">
     <div class="maps-col-content-wrapper">
       <h3 class="maps-col-item">{{ map.mapName | escape }}</h3>
       <p class="maps-col-item"><a class="maps-col-button button" href="{{ '/map/' | prepend: site.baseurl | append: map.slug }}/">View</a></p>
     </div>
   </div>
-  {%- endif -%}
-  {%- endfor %}
+  {% endif %}
+  {% endfor %}
 </div>

--- a/maps/skins.html
+++ b/maps/skins.html
@@ -4,14 +4,14 @@ title: Map Skins
 permalink: /maps-list/mods/
 ---
 <div class="maps-col-wrapper">
-  {%- for map in site.maps -%}
-  {%- if map.mapType == "MAP_SKIN" %}
+  {% for map in site.maps %}
+  {% if map.mapType == "MAP_SKIN" %}
     <div class="maps-col" data-map-name="{{ map.mapName | escape }}" data-map-name-slug="{{ map.slug }}">
       <div class="maps-col-content-wrapper">
         <h3 class="maps-col-item">{{ map.mapName | escape }}</h3>
         <p class="maps-col-item"><a class="maps-col-button button" href="{{ '/map/' | prepend: site.baseurl | append: map.slug }}/">View</a></p>
       </div>
     </div>
-  {%- endif -%}
-  {%- endfor %}
+  {% endif %}
+  {% endfor %}
 </div>


### PR DESCRIPTION
Getting various 'syntax' errors on startup using `jekyll serve`. Errors include things like the following:
```
  Liquid Exception: Liquid syntax error (line 2): 
Tag '{%- for map in site.maps -%}' was not properly terminated with regexp: /\%\}/ in maps/skins.html

  Liquid Exception: Liquid syntax error (line 5): 
Tag '{%- if map.mapCategory == "BEST" %}' was not properly terminated with regexp: /\%\}/ in maps/categories.html

  Liquid Exception: Invalid syntax for include tag: - Valid syntax:
 {% include file.ext param='value' param2='value' %} in _layouts/default.html
```

It seems that jekyll is not happy with the "-%}" notation and removing the dash resolves this and allows for the server to startup.