### PR TITLE
Move win32 download to a link

### DIFF
--- a/download.html
+++ b/download.html
@@ -10,10 +10,6 @@ permalink: /download/
   <img src="../images/operating-systems/windows100.png" alt="Windows Icon">
   <p>TripleA&nbsp;for Windows <strong>(64&nbsp;bit)</strong></p>
 </a>
-<a id="win32" href="https://github.com/triplea-game/triplea/releases/latest" target="_blank" class="button dl-links" onclick="hideShowInstallationText(document.getElementById('windows-install'))">
-  <img src="../images/operating-systems/windows100.png" alt="Windows Icon">
-  <p>TripleA&nbsp;for Windows <strong>(32&nbsp;bit)</strong></p>
-</a>
 <a id="macos" href="https://github.com/triplea-game/triplea/releases/latest" target="_blank" class="button dl-links" onclick="hideShowInstallationText(document.getElementById('mac-install'))">
   <img src="../images/operating-systems/mac100.png" alt="Mac Icon">
   <p>TripleA&nbsp;for Mac</p>
@@ -61,6 +57,11 @@ permalink: /download/
 
 <div>
   <h2>Additional Links</h2>
+
+  <p><a id="win32" href="https://github.com/triplea-game/triplea/releases/latest" target="_blank"
+     onclick="hideShowInstallationText(document.getElementById('windows-install'))">
+    Download TripleA&nbsp;for Windows <strong>32&nbsp;bit</strong>
+  </a></p>
   <p><a href="{{ '/release_notes/' | prepend: site.baseurl }}">Release Notes</a></p>
   <p><a href="https://github.com/triplea-game/triplea/wiki/Verifying-Binaries">Verifying Binaries</a></p>
   <p><a href="{{ '/old_downloads/' | prepend: site.baseurl }}">Previous TripleA Releases</a></p>


### PR DESCRIPTION
There are more than expected windows 32 bit downloads than we would expect. To discourage users from choosing the wrong windows distro, the win32 download button is converted here to a link to "hide it". This will hopefully make it easier to pick the right distribution version, and if someone is not paying a lot of attention and is clicking the first thing that they see that says "windows", then they'll click the 64 bit windows DL now instead of 'accidently' getting the 32 bit.

![Screenshot from 2019-06-10 11-13-53](https://user-images.githubusercontent.com/12397753/59221125-68fa8e80-8b7b-11e9-82ce-f6d7b6a5bd10.png)
