### PR TITLE
Use up-to-date CSS Validator

### DIFF
--- a/.travis/install_from_source
+++ b/.travis/install_from_source
@@ -13,7 +13,7 @@ rm "$VALIDATOR_TMP_ZIP"
 
 git clone https://github.com/w3c/css-validator.git
 cd ./css-validator/
-git checkout 6fa098871f6f60bd8471cfd0ee30a2a6a2f2f52a
+git checkout b4a908858e3faad282e90a215c45f853970531ad
 ant jar -q
 cd ..
 git clone https://github.com/RoiEXLab/link-checker.git


### PR DESCRIPTION
https://github.com/w3c/css-validator/pull/209 basically fixes the issues with our current build.
For some reason central.maven.org used to exist until now, but apparently does no longer.

Self Merging to fix the build and to not block all the other PRs.

/cc @DanVanAtta 