### PR TITLE
Improve how-to-host page

### DIFF
--- a/user-guide/bot-hosting.md
+++ b/user-guide/bot-hosting.md
@@ -1,0 +1,19 @@
+---
+layout: default
+title: How to Host a Bot
+permalink: /user-guide/bot-hosting
+---
+
+## How to Host a Bot
+
+You need to first be sure your computer can be reached from the public internet.
+See [how-to-host](/user-guide/how-to-host) for details.
+
+To install and run a bot:
+
+- Download the triplea-game-headless.zip file from [triplea releases](https://github.com/triplea-game/triplea/releases/latest)
+- Extract the Zip file.
+- The extracted zip file contains a `.bat` (for windows) and a `.sh` (for Mac and Linux) file that has properties for you to customize
+- Once done configuring properties, run the `.bat` or `.sh` file and you should see your bot connected to the lobby
+
+

--- a/user-guide/how-to-host.md
+++ b/user-guide/how-to-host.md
@@ -4,36 +4,46 @@ title: How to Host / Firewall Configuration
 permalink: /user-guide/how-to-host
 ---
 
-*Disclaimer*: Because this Guide heavily depends on the software AND hardware you are using, 
-I won't go into the details. Google or any other Search-Engine is your best friend!
 
 In order to allow requests to reach your computer we need to configure 2 Components:
-Configuring your Local Firewall
+
+## Configuring your Local Firewall
 
 Your Firewall is what blocks unallowed requests from being processed and/or answered from your Computer.
 This is a good thing, but in this case we need to setup a special rule for it in order to allow
  TripleA to be accessed by other clients over the web.
+
+
 On Windows it's often sufficient to just allow a single Application to communicate through the
- Firewall. You can add TripleA to the "Allowed Applications" in your Control Panel, if you are 
- not using the installer, you need to add java instead.
-On all operating systems you have the possibility to open single ports manually. TripleA uses 
-port 3300 by default.
+Firewall. You can add TripleA to the "Allowed Applications" in your Control Panel.
+
+
+On all operating systems you have the possibility to open single ports manually. 
+TripleA uses  port 3300 by default.
+
 DO NOT TURN OFF YOUR FIREWALL FOR A LONGER PERIOD OF TIME UNDER ANY CIRCUMSTANCES
-Finding your Firewall-Settings
-Windows
 
-Open your Control Panel, change the View By setting to "Small/Large Icons" and click on "Windows 
-Firewall">Allow a program or feature through Windows Firewall
-Linux
+### Finding your Firewall-Settings
 
-Based on the distribution you are using this will differ. On Debian based systems (including Ubuntu)
- you can use ufw (uncomplicated firewall) instead of manually messing with iptables. With ufw you just enter sudo ufw allow 3300 in a terminal. Done.
-If you are using Linux you probably know how to figure out how to do this on other distributions. 
-There are just too many to list them all.
-Mac
+**Windows**
 
-I have no idea... (If you are a mac user, please tell me so I can edit this in here later)
-Configuring your Router
+Open your Control Panel,  click on "Windows Firewall" > "Allow a program or feature through Windows Firewall"
+
+More detailed instructions can be found at: <https://www.windowscentral.com/how-open-port-windows-firewall>
+
+**Linux**
+
+This will very by distrubtion. On Ubuntu and Debian based systems using `ufw`, the command is:
+```
+ufw allow 3300
+```
+
+**Mac**
+
+See: <https://support.apple.com/en-us/HT201642>
+
+
+### Configure Port-Forwarding
 
 Assuming yor Computer is not connected directly to the internet, but connected to a router instead 
 which is most likely the case, we need to tell your Route it's supposed to route all TripleA-related 
@@ -46,39 +56,17 @@ If you are asked for the Protocol select TCP.
 
 ### Troubleshooting
 
-Computers often don't work like you want them to, here are some tricks that might come in handy 
-if something is not working for you:
-Try temporarily disabling your Firewall. If everything is working fine with your Firewall disabled,
+* Try temporarily disabling your Firewall. If everything is working fine with your Firewall disabled,
  you haven't setup your Firewall correctly. If it's still not working your Router isn't correctly 
  forwarding the traffic to your PC.
 
 [canyouseeme.org](https://canyouseeme.org) is a website that helps you checking if your configuration is 
 working. Just enter the port you want to check (in our case 3300).
 
-If you still have any questions, feel free to ask!
+[whatismyip](https://whatismyipaddress.com) can be used to double check your public facing IP address,
+it must be accessible from other computes.
 
 
-### Bot Hosting
-Anyone that can host can host bots.
+If you still have any questions, feel free to ask on the player help forum:
+<https://forums.triplea-game.org/category/10/player-help>
 
-Now you will need to place a bot folder or multiple ones, in the same TripleA program folder. 
-The below is an example of one of my bots. Using windows. Other operating systems are slightly 
-different.
-
-```
-@echo off
-SET PORT=3363
-SET BOT_NAME=Bot01_<YOUR_NAME>
-SET BOT_NUMBER=25
-
-SET LOBBY_HOST=45.79.144.53
-SET LOBBY_PORT=3304
-
-java -server -Xmx320m -Djava.awt.headless=true -classpath bin/triplea.jar games.strategy.engine.framework.headlessGameServer.HeadlessGameServer -Ptriplea.port=%PORT% -Ptriplea.lobby.host=%LOBBY_HOST% -Ptriplea.lobby.port=%LOBBY_PORT% -Ptriplea.name=%BOT_NAME%
-pause
-```
-
-Save the above to a notepad file and rename it with the name and number that you wish for your bot.
-Make sure it is using one of the correct port numbers you have opened on your router. Now 
-resave the notepad file as a .bat file and place it in your Triple program folder. Test to see if 
-your bot launches in the lobby. 

--- a/user-guide/index.md
+++ b/user-guide/index.md
@@ -17,5 +17,5 @@ permalink: /user-guide/
 
 ## How-To
 * [How to Host and Firewall Configuration](how-to-host)
-
+* [How to Host a Bot](bot-hosting)
 


### PR DESCRIPTION
- Formatting
- Reduce unnecessary information
- Remove 'first person' voice
- Add links for more details on firewall rules
- Move 'bot hosting' to a dedicated page