### PR TITLE
Remove link to 'verifying binaries'

### DIFF
--- a/download.html
+++ b/download.html
@@ -66,7 +66,6 @@ permalink: /download/
 <div>
   <h2>Additional Links</h2>
   <p><a href="{{ '/release_notes/' | prepend: site.baseurl }}">Release Notes</a></p>
-  <p><a href="https://github.com/triplea-game/triplea/wiki/Verifying-Binaries">Verifying Binaries</a></p>
   <p><a href="{{ '/old_downloads/' | prepend: site.baseurl }}">Previous TripleA Releases</a></p>
   <p><a id="sourceLink" href="https://github.com/triplea-game/triplea/releases/latest">Download Latest Source Code</a></p>
   <p><a href="https://github.com/triplea-game/triplea/releases/">Download Pre-Release</a></p>


### PR DESCRIPTION
GPG signing broke and was disabled. Verifying binaries in this manner can no longer
be done, the instructions to do so are hence out of date.

More background information is available at:
  https://github.com/triplea-game/triplea/issues/7426