### PR TITLE
Remove-prerelease notice and map version map pages

### DIFF
--- a/_layouts/map.html
+++ b/_layouts/map.html
@@ -7,6 +7,5 @@ layout: default
 <img src="{% if page.img %}{{ page.img }}{% else %}{{ '/images/missing_map.png' | prepend: site.baseurl }}{% endif %}" alt="Map Thumbnail">
 {{ content }}
 <br>
-<a href="triplea:{{ page.mapName | escape | uri_escape }}" class="button">Download with TripleA</a>
-<p style="margin-top: -20px; font-size: 12px;">(Requires pre-release 1.9.0.0.6322 or higher)</p><!-- TODO remove this notice once a new stable release with this feature is out -->
-<a href="{{ page.downloadUrl }}">Manual Download (v{{ page.version }})</a>
+<a href="triplea:{{ page.mapName | escape | uri_scape }}" class="button">Download with TripleA</a>
+<a href="{{ page.downloadUrl }}">Manual Download</a>


### PR DESCRIPTION
Remove 'pre-release' notice, the 1.9 version referenced is quite
old now.

The 'version' listed is the notification version and is not very
significant to users. It is also confusing compared to the version of
the map itself. To simplify, it is being removed.