### PR TITLE
Restore old_downloads page with redirect

### DIFF
--- a/old_downloads.html
+++ b/old_downloads.html
@@ -1,0 +1,10 @@
+---
+layout: page
+title: Older TripleA Releases
+permalink: /old_downloads/
+---
+
+<script>
+  window.location.replace("/release_notes");
+</script>
+


### PR DESCRIPTION
To avoid breaking any existing links, redirect the old_downloads
page to release notes