### PR TITLE
Remove copyright statement in footer

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -36,7 +36,4 @@
     fjs.parentNode.insertBefore(js, fjs);
     }(document, 'script', 'facebook-jssdk'));</script>
   <span class="fb-like" data-href="http://www.triplea-game.org/" data-layout="button_count" data-action="like" data-show-faces="true" data-share="true"></span>
-  <br>
-  <br>
-  <p class="footer-text"> &copy; 2019 TripleA Contributors. Usage of this software is subject to the <a href="https://www.gnu.org/copyleft/gpl.html">GPL</a>.</p>
 </footer>


### PR DESCRIPTION
- It is out of date by a few years
- We already have copyright info on the home page in the license section