### PR TITLE
Remove facebook like button

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -27,13 +27,4 @@
         </ul>
     </div>
   </div>
-  <div id="fb-root"></div>
-  <script>(function(d, s, id) {
-    var js, fjs = d.getElementsByTagName(s)[0];
-    if (d.getElementById(id)) return;
-    js = d.createElement(s); js.id = id;
-    js.src = "//connect.facebook.net/en_US/sdk.js#xfbml=1&version=v2.6";
-    fjs.parentNode.insertBefore(js, fjs);
-    }(document, 'script', 'facebook-jssdk'));</script>
-  <span class="fb-like" data-href="http://www.triplea-game.org/" data-layout="button_count" data-action="like" data-show-faces="true" data-share="true"></span>
 </footer>


### PR DESCRIPTION
- Under-utilized
- Not clear it is doing much for us
- A non-zero number of network requests when requesting our homepage are
  for Facebook tracking javascripts
- There are implications to allowing Facebook to track all of our
  site visitors. Given there is questionable value in this integration,
  this is a liability with seemingly little benefit.