### PR TITLE
Use jekyll-seo gem to generate meta info

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ On Ubuntu, run:
 ```bash
 sudo apt install ruby ruby-dev make gcc
 sudo gem install jekyll bundler
+sudo gem install jekyll-seo-tag
 ```
 
 **2. Run a local version of the website.** Using Git, clone the latest version of this repository

--- a/_config.yml
+++ b/_config.yml
@@ -20,3 +20,7 @@ defaults:
 exclude:
   - README.md
   - CNAME
+
+plugins:
+  - jekyll-seo-tag
+

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -3,11 +3,8 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
   <title>{% if page.title %}{{ page.title }}{% else %}{{ site.title }}{% endif %}</title>
-  <meta name="description" content="{% if page.excerpt %}{{ page.excerpt | strip_html | strip_newlines | escape | truncate: 160 }}{% else %}{{ site.description | escape }}{% endif %}">
-
   <link rel="stylesheet" href="{{ '/css/main.css' | prepend: site.baseurl }}" type="text/css">
   <link rel="stylesheet" href="{{ '/css/fonts/stylesheet.css' | prepend: site.baseurl }}" type="text/css">
-  <link rel="canonical" href="{{ page.url | replace:'index.html','' | prepend: site.baseurl | prepend: site.url }}">
 
   <link rel="shortcut icon" href="{{ '/images/favicon.ico' | prepend: site.baseurl }}" type="image/x-icon">
   <link rel="icon" href="{{ '/images/favicon.ico' | prepend: site.baseurl }}" type="image/x-icon">
@@ -20,4 +17,5 @@
     "logo": "http://triplea-game.org/images/icon_menu.png"
   }
   </script>
+  {% seo %}
 </head>


### PR DESCRIPTION
- add instructions to install new gem, mostly per: https://github.com/jekyll/jekyll-seo-tag/blob/master/docs/installation.md
- adds magic seo generator to header & removes newly redundant meta tags

Addresses #339