### PR TITLE
Remove PDF version of rulebooks

### DIFF
--- a/user-guide/index.md
+++ b/user-guide/index.md
@@ -11,9 +11,8 @@ permalink: /user-guide/
 * [How to Host a Lobby Bot](bot-hosting)
 
 ## Game Rules
-* [TripleA Game Rules Manual (PDF)]({{ '/files/TripleA_RuleBook.pdf' | prepend: site.baseurl }})
-* [TripleA Game Rules Manual (HTML - work in progress)](rule-book)
-* [Tactical Handbook (HTML - work in progress)](tactical-handbook)
+* [TripleA Game Rules Manual](rule-book)
+* [Tactical Handbook](tactical-handbook)
 
 ## User Conduct Rules
 * [Lobby Rules](lobby-rules)


### PR DESCRIPTION
This leaves only the HTML versions. It is therefore less to 'fix' (there is still work needed). Of biggest note, anything that was out of sync between PDF and HTML, is no longer an issue (the HTML version would be the most up to date).

Helps address part of #347, reduces the size of the problem noted in #347.